### PR TITLE
feat: replace checkbox hack with React state in ListWithFiltersLayout

### DIFF
--- a/src/components/Collection/__snapshots__/Collection.spec.tsx.snap
+++ b/src/components/Collection/__snapshots__/Collection.spec.tsx.snap
@@ -72952,12 +72952,6 @@ exports[`Collection > renders 1`] = `
             
           "
           >
-            <input
-              class="hidden"
-              data-drawer="true"
-              id="hiddenState"
-              type="checkbox"
-            />
             <div
               class="
         grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container
@@ -73041,7 +73035,10 @@ exports[`Collection > renders 1`] = `
                   </select>
                 </label>
               </div>
-              <a
+              <button
+                aria-controls="filters"
+                aria-expanded="false"
+                aria-label="Toggle filters"
                 class="
           col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center
           justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted
@@ -73049,10 +73046,10 @@ exports[`Collection > renders 1`] = `
           hover:scale-110
           tablet:col-start-5 tablet:w-20
         "
-                href="#filters"
+                type="button"
               >
                 Filter
-              </a>
+              </button>
             </div>
           </div>
           <div
@@ -80191,6 +80188,16 @@ exports[`Collection > renders 1`] = `
             </div>
           </div>
           <div
+            aria-hidden="true"
+            class="
+            invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0
+            transition-opacity duration-200
+            tablet-landscape:hidden
+            
+          "
+          />
+          <div
+            aria-label="Filters"
             class="
             fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px]
             flex-col items-start gap-y-5 bg-default text-left text-inverse
@@ -80655,17 +80662,17 @@ exports[`Collection > renders 1`] = `
                 tablet-landscape:hidden
               "
               >
-                <a
+                <button
                   class="
-                  flex cursor-pointer items-center justify-center gap-x-4
+                  flex w-full cursor-pointer items-center justify-center gap-x-4
                   bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse
                   uppercase
                   tablet-landscape:hidden
                 "
-                  href="#list"
+                  type="button"
                 >
                   View 210 Results
-                </a>
+                </button>
               </div>
             </div>
           </div>

--- a/src/components/ListWithFiltersLayout.tsx
+++ b/src/components/ListWithFiltersLayout.tsx
@@ -66,36 +66,39 @@ export function ListWithFiltersLayout<T extends string>({
   const filtersRef = useRef<HTMLDivElement | null>(null);
   const toggleButtonRef = useRef<HTMLButtonElement | null>(null);
 
-  const onFilterClick = useCallback((event: React.MouseEvent) => {
-    const documentSize = document.documentElement.clientWidth;
-    const tabletLandscapeBreakpoint = Number.parseFloat(
-      globalThis
-        .getComputedStyle(document.body)
-        .getPropertyValue("--breakpoint-tablet-landscape"),
-    );
+  const onFilterClick = useCallback(
+    (event: React.MouseEvent) => {
+      const documentSize = document.documentElement.clientWidth;
+      const tabletLandscapeBreakpoint = Number.parseFloat(
+        globalThis
+          .getComputedStyle(document.body)
+          .getPropertyValue("--breakpoint-tablet-landscape"),
+      );
 
-    if (documentSize >= tabletLandscapeBreakpoint) {
-      setFilterDrawerVisible(false);
-      return event;
-    }
+      if (documentSize >= tabletLandscapeBreakpoint) {
+        setFilterDrawerVisible(false);
+        return event;
+      }
 
-    event.preventDefault();
-    
-    if (filterDrawerVisible) {
-      document.body.classList.remove("overflow-hidden");
-      setFilterDrawerVisible(false);
-    } else {
-      document.body.classList.add("overflow-hidden");
-      setFilterDrawerVisible(true);
-      // Focus first focusable element after drawer opens
-      requestAnimationFrame(() => {
-        const firstFocusable = filtersRef.current?.querySelector<HTMLElement>(
-          'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
-        );
-        firstFocusable?.focus();
-      });
-    }
-  }, [filterDrawerVisible]);
+      event.preventDefault();
+
+      if (filterDrawerVisible) {
+        document.body.classList.remove("overflow-hidden");
+        setFilterDrawerVisible(false);
+      } else {
+        document.body.classList.add("overflow-hidden");
+        setFilterDrawerVisible(true);
+        // Focus first focusable element after drawer opens
+        requestAnimationFrame(() => {
+          const firstFocusable = filtersRef.current?.querySelector<HTMLElement>(
+            'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+          );
+          firstFocusable?.focus();
+        });
+      }
+    },
+    [filterDrawerVisible],
+  );
 
   // Handle escape key
   useEffect(() => {
@@ -171,7 +174,7 @@ export function ListWithFiltersLayout<T extends string>({
         >
           {list}
         </div>
-        
+
         {/* Backdrop for mobile filters */}
         <div
           aria-hidden="true"
@@ -183,7 +186,7 @@ export function ListWithFiltersLayout<T extends string>({
           `}
           onClick={() => setFilterDrawerVisible(false)}
         />
-        
+
         <div
           aria-label="Filters"
           className={`

--- a/src/components/Overrated/__snapshots__/Overrated.spec.tsx.snap
+++ b/src/components/Overrated/__snapshots__/Overrated.spec.tsx.snap
@@ -76000,12 +76000,6 @@ exports[`Overrated > renders 1`] = `
             
           "
           >
-            <input
-              class="hidden"
-              data-drawer="true"
-              id="hiddenState"
-              type="checkbox"
-            />
             <div
               class="
         grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container
@@ -76094,7 +76088,10 @@ exports[`Overrated > renders 1`] = `
                   </select>
                 </label>
               </div>
-              <a
+              <button
+                aria-controls="filters"
+                aria-expanded="false"
+                aria-label="Toggle filters"
                 class="
           col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center
           justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted
@@ -76102,10 +76099,10 @@ exports[`Overrated > renders 1`] = `
           hover:scale-110
           tablet:col-start-5 tablet:w-20
         "
-                href="#filters"
+                type="button"
               >
                 Filter
-              </a>
+              </button>
             </div>
           </div>
           <div
@@ -87402,6 +87399,16 @@ exports[`Overrated > renders 1`] = `
             </div>
           </div>
           <div
+            aria-hidden="true"
+            class="
+            invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0
+            transition-opacity duration-200
+            tablet-landscape:hidden
+            
+          "
+          />
+          <div
+            aria-label="Filters"
             class="
             fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px]
             flex-col items-start gap-y-5 bg-default text-left text-inverse
@@ -88482,17 +88489,17 @@ exports[`Overrated > renders 1`] = `
                 tablet-landscape:hidden
               "
               >
-                <a
+                <button
                   class="
-                  flex cursor-pointer items-center justify-center gap-x-4
+                  flex w-full cursor-pointer items-center justify-center gap-x-4
                   bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse
                   uppercase
                   tablet-landscape:hidden
                 "
-                  href="#list"
+                  type="button"
                 >
                   View 165 Results
-                </a>
+                </button>
               </div>
             </div>
           </div>

--- a/src/components/Underrated/__snapshots__/Underrated.spec.tsx.snap
+++ b/src/components/Underrated/__snapshots__/Underrated.spec.tsx.snap
@@ -75328,12 +75328,6 @@ exports[`Underrated > renders 1`] = `
             
           "
           >
-            <input
-              class="hidden"
-              data-drawer="true"
-              id="hiddenState"
-              type="checkbox"
-            />
             <div
               class="
         grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container
@@ -75422,7 +75416,10 @@ exports[`Underrated > renders 1`] = `
                   </select>
                 </label>
               </div>
-              <a
+              <button
+                aria-controls="filters"
+                aria-expanded="false"
+                aria-label="Toggle filters"
                 class="
           col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center
           justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted
@@ -75430,10 +75427,10 @@ exports[`Underrated > renders 1`] = `
           hover:scale-110
           tablet:col-start-5 tablet:w-20
         "
-                href="#filters"
+                type="button"
               >
                 Filter
-              </a>
+              </button>
             </div>
           </div>
           <div
@@ -86133,6 +86130,16 @@ exports[`Underrated > renders 1`] = `
             />
           </div>
           <div
+            aria-hidden="true"
+            class="
+            invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0
+            transition-opacity duration-200
+            tablet-landscape:hidden
+            
+          "
+          />
+          <div
+            aria-label="Filters"
             class="
             fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px]
             flex-col items-start gap-y-5 bg-default text-left text-inverse
@@ -87063,17 +87070,17 @@ exports[`Underrated > renders 1`] = `
                 tablet-landscape:hidden
               "
               >
-                <a
+                <button
                   class="
-                  flex cursor-pointer items-center justify-center gap-x-4
+                  flex w-full cursor-pointer items-center justify-center gap-x-4
                   bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse
                   uppercase
                   tablet-landscape:hidden
                 "
-                  href="#list"
+                  type="button"
                 >
                   View 91 Results
-                </a>
+                </button>
               </div>
             </div>
           </div>

--- a/src/components/Underseen/__snapshots__/Underseen.spec.tsx.snap
+++ b/src/components/Underseen/__snapshots__/Underseen.spec.tsx.snap
@@ -43848,12 +43848,6 @@ exports[`Underseen > renders 1`] = `
             
           "
           >
-            <input
-              class="hidden"
-              data-drawer="true"
-              id="hiddenState"
-              type="checkbox"
-            />
             <div
               class="
         grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container
@@ -43942,7 +43936,10 @@ exports[`Underseen > renders 1`] = `
                   </select>
                 </label>
               </div>
-              <a
+              <button
+                aria-controls="filters"
+                aria-expanded="false"
+                aria-label="Toggle filters"
                 class="
           col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center
           justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted
@@ -43950,10 +43947,10 @@ exports[`Underseen > renders 1`] = `
           hover:scale-110
           tablet:col-start-5 tablet:w-20
         "
-                href="#filters"
+                type="button"
               >
                 Filter
-              </a>
+              </button>
             </div>
           </div>
           <div
@@ -51264,6 +51261,16 @@ exports[`Underseen > renders 1`] = `
             />
           </div>
           <div
+            aria-hidden="true"
+            class="
+            invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0
+            transition-opacity duration-200
+            tablet-landscape:hidden
+            
+          "
+          />
+          <div
+            aria-label="Filters"
             class="
             fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px]
             flex-col items-start gap-y-5 bg-default text-left text-inverse
@@ -52094,17 +52101,17 @@ exports[`Underseen > renders 1`] = `
                 tablet-landscape:hidden
               "
               >
-                <a
+                <button
                   class="
-                  flex cursor-pointer items-center justify-center gap-x-4
+                  flex w-full cursor-pointer items-center justify-center gap-x-4
                   bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse
                   uppercase
                   tablet-landscape:hidden
                 "
-                  href="#list"
+                  type="button"
                 >
                   View 60 Results
-                </a>
+                </button>
               </div>
             </div>
           </div>

--- a/src/components/Viewings/__snapshots__/Viewings.spec.tsx.snap
+++ b/src/components/Viewings/__snapshots__/Viewings.spec.tsx.snap
@@ -15754,12 +15754,6 @@ exports[`Viewings > renders 1`] = `
             
           "
           >
-            <input
-              class="hidden"
-              data-drawer="true"
-              id="hiddenState"
-              type="checkbox"
-            />
             <div
               class="
         grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container
@@ -15834,7 +15828,10 @@ exports[`Viewings > renders 1`] = `
                   </select>
                 </label>
               </div>
-              <a
+              <button
+                aria-controls="filters"
+                aria-expanded="false"
+                aria-label="Toggle filters"
                 class="
           col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center
           justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted
@@ -15842,10 +15839,10 @@ exports[`Viewings > renders 1`] = `
           hover:scale-110
           tablet:col-start-5 tablet:w-20
         "
-                href="#filters"
+                type="button"
               >
                 Filter
-              </a>
+              </button>
             </div>
           </div>
           <div
@@ -17107,6 +17104,16 @@ exports[`Viewings > renders 1`] = `
             </div>
           </div>
           <div
+            aria-hidden="true"
+            class="
+            invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0
+            transition-opacity duration-200
+            tablet-landscape:hidden
+            
+          "
+          />
+          <div
+            aria-label="Filters"
             class="
             fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px]
             flex-col items-start gap-y-5 bg-default text-left text-inverse
@@ -18640,17 +18647,17 @@ exports[`Viewings > renders 1`] = `
                 tablet-landscape:hidden
               "
               >
-                <a
+                <button
                   class="
-                  flex cursor-pointer items-center justify-center gap-x-4
+                  flex w-full cursor-pointer items-center justify-center gap-x-4
                   bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse
                   uppercase
                   tablet-landscape:hidden
                 "
-                  href="#list"
+                  type="button"
                 >
                   View 1609 Results
-                </a>
+                </button>
               </div>
             </div>
           </div>

--- a/src/components/Watchlist/__snapshots__/Watchlist.spec.tsx.snap
+++ b/src/components/Watchlist/__snapshots__/Watchlist.spec.tsx.snap
@@ -67945,12 +67945,6 @@ exports[`/watchlist > renders 1`] = `
             
           "
           >
-            <input
-              class="hidden"
-              data-drawer="true"
-              id="hiddenState"
-              type="checkbox"
-            />
             <div
               class="
         grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container
@@ -68030,7 +68024,10 @@ exports[`/watchlist > renders 1`] = `
                   </select>
                 </label>
               </div>
-              <a
+              <button
+                aria-controls="filters"
+                aria-expanded="false"
+                aria-label="Toggle filters"
                 class="
           col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center
           justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted
@@ -68038,10 +68035,10 @@ exports[`/watchlist > renders 1`] = `
           hover:scale-110
           tablet:col-start-5 tablet:w-20
         "
-                href="#filters"
+                type="button"
               >
                 Filter
-              </a>
+              </button>
             </div>
           </div>
           <div
@@ -73648,6 +73645,16 @@ exports[`/watchlist > renders 1`] = `
             </div>
           </div>
           <div
+            aria-hidden="true"
+            class="
+            invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0
+            transition-opacity duration-200
+            tablet-landscape:hidden
+            
+          "
+          />
+          <div
+            aria-label="Filters"
             class="
             fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px]
             flex-col items-start gap-y-5 bg-default text-left text-inverse
@@ -75251,17 +75258,17 @@ exports[`/watchlist > renders 1`] = `
                 tablet-landscape:hidden
               "
               >
-                <a
+                <button
                   class="
-                  flex cursor-pointer items-center justify-center gap-x-4
+                  flex w-full cursor-pointer items-center justify-center gap-x-4
                   bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse
                   uppercase
                   tablet-landscape:hidden
                 "
-                  href="#list"
+                  type="button"
                 >
                   View 3164 Results
-                </a>
+                </button>
               </div>
             </div>
           </div>

--- a/src/layouts/tailwind.css
+++ b/src/layouts/tailwind.css
@@ -6,6 +6,7 @@
   --z-index-base: 1;
   --z-index-sticky: 10;
   --z-index-nav-backdrop: 15;
+  --z-index-side-drawer-backdrop: 15;
   --z-index-nav-menu: 20;
   --z-index-hover: 30;
   --z-index-nav-toggle: 40;

--- a/src/pages/cast-and-crew/[slug]/__snapshots__/burt-reynolds.html
+++ b/src/pages/cast-and-crew/[slug]/__snapshots__/burt-reynolds.html
@@ -245,7 +245,7 @@
       })();
     </script>
     <astro-island
-      uid="ZIaKwQ"
+      uid="ZFg1SM"
       prefix="r1"
       component-url="~/components/CastAndCrewMember/CastAndCrewMember"
       component-export="CastAndCrewMember"
@@ -575,12 +575,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -618,11 +612,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -6301,6 +6299,11 @@
                 </div>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -6493,13 +6496,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->112<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->112<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/cast-and-crew/[slug]/__snapshots__/christopher-lee.html
+++ b/src/pages/cast-and-crew/[slug]/__snapshots__/christopher-lee.html
@@ -245,7 +245,7 @@
       })();
     </script>
     <astro-island
-      uid="15n60v"
+      uid="ZqNi7W"
       prefix="r1"
       component-url="~/components/CastAndCrewMember/CastAndCrewMember"
       component-export="CastAndCrewMember"
@@ -574,12 +574,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -617,11 +611,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -6197,6 +6195,11 @@
                 </div>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -6417,13 +6420,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->195<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->195<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/cast-and-crew/[slug]/__snapshots__/john-wayne.html
+++ b/src/pages/cast-and-crew/[slug]/__snapshots__/john-wayne.html
@@ -245,7 +245,7 @@
       })();
     </script>
     <astro-island
-      uid="Zia7bJ"
+      uid="2jModB"
       prefix="r1"
       component-url="~/components/CastAndCrewMember/CastAndCrewMember"
       component-export="CastAndCrewMember"
@@ -575,12 +575,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -618,11 +612,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -6202,6 +6200,11 @@
                 </div>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -6409,13 +6412,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->146<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->146<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/cast-and-crew/__snapshots__/index.html
+++ b/src/pages/cast-and-crew/__snapshots__/index.html
@@ -245,7 +245,7 @@
       })();
     </script>
     <astro-island
-      uid="2g8DTW"
+      uid="1mKmy9"
       prefix="r1"
       component-url="~/components/CastAndCrew/CastAndCrew"
       component-export="CastAndCrew"
@@ -726,12 +726,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full top-[52px] scroll-mt-[52px]"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -764,11 +758,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -3893,6 +3891,11 @@
                 </ol>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -3932,13 +3935,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->68<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->68<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/collections/[slug]/__snapshots__/friday-the-13th.html
+++ b/src/pages/collections/[slug]/__snapshots__/friday-the-13th.html
@@ -247,7 +247,7 @@
       })();
     </script>
     <astro-island
-      uid="1oiT1q"
+      uid="2meFM"
       prefix="r1"
       component-url="~/components/Collection/Collection"
       component-export="Collection"
@@ -578,12 +578,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -621,11 +615,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -1418,6 +1416,11 @@
                 ></div>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -1539,13 +1542,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->12<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->12<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/collections/[slug]/__snapshots__/hatchet.html
+++ b/src/pages/collections/[slug]/__snapshots__/hatchet.html
@@ -247,7 +247,7 @@
       })();
     </script>
     <astro-island
-      uid="ZXoKk6"
+      uid="Z23DtPD"
       prefix="r1"
       component-url="~/components/Collection/Collection"
       component-export="Collection"
@@ -578,12 +578,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -621,11 +615,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -903,6 +901,11 @@
                 ></div>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -994,13 +997,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->4<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->4<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/collections/[slug]/__snapshots__/james-bond.html
+++ b/src/pages/collections/[slug]/__snapshots__/james-bond.html
@@ -247,7 +247,7 @@
       })();
     </script>
     <astro-island
-      uid="1vvvnO"
+      uid="Z1OTtNX"
       prefix="r1"
       component-url="~/components/Collection/Collection"
       component-export="Collection"
@@ -576,12 +576,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -619,11 +613,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -2354,6 +2352,11 @@
                 ></div>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -2505,13 +2508,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->27<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->27<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/collections/__snapshots__/index.html
+++ b/src/pages/collections/__snapshots__/index.html
@@ -242,7 +242,7 @@
       })();
     </script>
     <astro-island
-      uid="ZfJUGQ"
+      uid="ZQOMVh"
       prefix="r1"
       component-url="~/components/Collections/Collections"
       component-export="Collections"
@@ -559,12 +559,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -603,11 +597,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -961,6 +959,11 @@
                 </ol>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -988,13 +991,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->10<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->10<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/reviews/__snapshots__/index.html
+++ b/src/pages/reviews/__snapshots__/index.html
@@ -239,7 +239,7 @@
       })();
     </script>
     <astro-island
-      uid="Z8yIrI"
+      uid="gzaaa"
       prefix="r1"
       component-url="~/components/Reviews/Reviews"
       component-export="Reviews"
@@ -598,12 +598,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -644,11 +638,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -7155,6 +7153,11 @@
                 </div>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -7728,13 +7731,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->711<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->711<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/reviews/overrated/__snapshots__/index.html
+++ b/src/pages/reviews/overrated/__snapshots__/index.html
@@ -245,7 +245,7 @@
       })();
     </script>
     <astro-island
-      uid="cjTjJ"
+      uid="1Kxzyh"
       prefix="r1"
       component-url="~/components/Overrated/Overrated"
       component-export="Overrated"
@@ -603,12 +603,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -647,11 +641,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -7703,6 +7701,11 @@
                 </div>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -8176,13 +8179,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->165<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->165<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/reviews/underrated/__snapshots__/index.html
+++ b/src/pages/reviews/underrated/__snapshots__/index.html
@@ -245,7 +245,7 @@
       })();
     </script>
     <astro-island
-      uid="IvlhH"
+      uid="zg8YL"
       prefix="r1"
       component-url="~/components/Underrated/Underrated"
       component-export="Underrated"
@@ -603,12 +603,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -647,11 +641,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -7312,6 +7310,11 @@
                 ></div>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -7755,13 +7758,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->91<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->91<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/reviews/underseen/__snapshots__/index.html
+++ b/src/pages/reviews/underseen/__snapshots__/index.html
@@ -245,7 +245,7 @@
       })();
     </script>
     <astro-island
-      uid="oxbjJ"
+      uid="ZvzLqn"
       prefix="r1"
       component-url="~/components/Underseen/Underseen"
       component-export="Underseen"
@@ -604,12 +604,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -648,11 +642,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -5162,6 +5160,11 @@
                 ></div>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -5585,13 +5588,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->60<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->60<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/viewings/__snapshots__/index.html
+++ b/src/pages/viewings/__snapshots__/index.html
@@ -242,7 +242,7 @@
       })();
     </script>
     <astro-island
-      uid="28w6J9"
+      uid="Z2blUBt"
       prefix="r1"
       component-url="~/components/Viewings/Viewings"
       component-export="Viewings"
@@ -559,12 +559,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -603,11 +597,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -1355,6 +1353,11 @@
                 </div>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -1732,13 +1735,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->1609<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->1609<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>

--- a/src/pages/watchlist/__snapshots__/index.html
+++ b/src/pages/watchlist/__snapshots__/index.html
@@ -242,7 +242,7 @@
       })();
     </script>
     <astro-island
-      uid="ZYzsLL"
+      uid="1UxKRo"
       prefix="r1"
       component-url="~/components/Watchlist/Watchlist"
       component-export="Watchlist"
@@ -559,12 +559,6 @@
               <div
                 class="sticky top-0 z-sticky border-b border-default bg-default text-xs tablet:col-span-full"
               >
-                <input
-                  class="hidden"
-                  data-drawer="true"
-                  id="hiddenState"
-                  type="checkbox"
-                />
                 <div
                   class="grid grid-cols-[auto_auto_1fr_auto] items-baseline gap-y-7 px-container py-10 font-sans font-medium tracking-wide text-subtle uppercase tablet:grid-cols-[auto_auto_1fr_auto_auto] tablet:gap-x-4 tablet-landscape:grid-cols-[auto_auto_1fr_minmax(302px,calc(33%_-_192px))_auto]"
                 >
@@ -604,11 +598,15 @@
                       </select></label
                     >
                   </div>
-                  <a
+                  <button
+                    aria-controls="filters"
+                    aria-expanded="false"
+                    aria-label="Toggle filters"
                     class="col-start-4 row-start-1 flex transform-gpu cursor-pointer items-center justify-center gap-x-4 bg-canvas px-4 py-2 text-nowrap text-muted uppercase shadow-all transition-transform hover:scale-110 tablet:col-start-5 tablet:w-20"
-                    href="#filters"
-                    >Filter</a
+                    type="button"
                   >
+                    Filter
+                  </button>
                 </div>
               </div>
               <div
@@ -4854,6 +4852,11 @@
                 </div>
               </div>
               <div
+                aria-hidden="true"
+                class="invisible fixed inset-0 bg-[rgba(0,0,0,.4)] opacity-0 transition-opacity duration-200 tablet-landscape:hidden"
+              ></div>
+              <div
+                aria-label="Filters"
                 class="fixed top-0 right-0 z-filter-drawer flex h-full max-w-[380px] flex-col items-start gap-y-5 bg-default text-left text-inverse duration-200 ease-in-out w-0 transform-[translateX(100%)] overflow-y-hidden tablet:gap-y-10 tablet-landscape:relative tablet-landscape:z-auto tablet-landscape:col-start-4 tablet-landscape:block tablet-landscape:w-auto tablet-landscape:max-w-unset tablet-landscape:min-w-[320px] tablet-landscape:transform-none tablet-landscape:bg-inherit tablet-landscape:py-24 tablet-landscape:pb-12 tablet-landscape:drop-shadow-none"
                 id="filters"
               >
@@ -5242,13 +5245,14 @@
                   <div
                     class="sticky bottom-0 z-filter-footer mt-auto w-full self-end border-t border-t-default bg-default px-8 py-4 drop-shadow-2xl tablet-landscape:hidden"
                   >
-                    <a
-                      class="flex cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
-                      href="#list"
-                      >View
-                      <!-- -->3164<!-- -->
-                      Results</a
+                    <button
+                      class="flex w-full cursor-pointer items-center justify-center gap-x-4 bg-footer px-4 py-3 font-sans text-xs text-nowrap text-inverse uppercase tablet-landscape:hidden"
+                      type="button"
                     >
+                      View
+                      <!-- -->3164<!-- -->
+                      Results
+                    </button>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Replace CSS checkbox hack with React state management for the filters drawer
- Improve accessibility and user experience with proper focus management
- Add smooth backdrop animation and click-outside-to-close functionality

## Changes
- Converted filter toggle from anchor to button element with proper ARIA attributes
- Added React hooks for state management and event handling
- Implemented backdrop overlay for mobile with fade animation
- Added escape key handler to close drawer
- Added click outside handler to close drawer
- Added focus management - focuses first element when drawer opens
- Added scroll-to-list functionality when "View Results" is clicked
- Created new `z-side-drawer-backdrop` theme value for reusable backdrop z-index
- Removed unused checkbox input and associated handlers
- Updated all test snapshots to reflect the new structure

## Test Plan
- [x] Filters drawer opens/closes on mobile
- [x] Backdrop appears/disappears with smooth animation
- [x] Escape key closes the drawer
- [x] Clicking outside closes the drawer
- [x] Clicking "View Results" closes drawer and scrolls to list
- [x] Focus moves to first element in drawer when opened
- [x] Focus returns to toggle button when closed with Escape
- [x] Body scroll is prevented when drawer is open
- [x] All tests pass with updated snapshots
- [x] Lint and knip checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)