### PR TITLE
feat: add scroll to filters and focus on filter button click for desktop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,10 @@ This site uses Astro's partial hydration strategy:
 
 ## Development Workflow
 
-1. Create feature branch from main
+1. **IMPORTANT**: Always create a new feature branch for new features:
+   - `git checkout -b feat/feature-name` for features
+   - `git checkout -b fix/bug-name` for bug fixes
+   - `git checkout -b chore/task-name` for maintenance tasks
 2. Make changes with proper types
 3. Run tests and linting
 4. **IMPORTANT**: Before creating any PR, run:

--- a/src/components/ListWithFiltersLayout.tsx
+++ b/src/components/ListWithFiltersLayout.tsx
@@ -77,7 +77,20 @@ export function ListWithFiltersLayout<T extends string>({
 
       if (documentSize >= tabletLandscapeBreakpoint) {
         setFilterDrawerVisible(false);
-        return event;
+        event.preventDefault();
+        
+        // Scroll to the filters and focus first input
+        document.querySelector("#filters")?.scrollIntoView();
+        
+        // Delay focus to allow smooth scroll to complete
+        setTimeout(() => {
+          const firstFocusable = filtersRef.current?.querySelector<HTMLElement>(
+            'button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+          );
+          firstFocusable?.focus();
+        }, 500); // Wait for scroll animation to complete
+        
+        return;
       }
 
       event.preventDefault();

--- a/src/components/ListWithFiltersLayout.tsx
+++ b/src/components/ListWithFiltersLayout.tsx
@@ -78,10 +78,10 @@ export function ListWithFiltersLayout<T extends string>({
       if (documentSize >= tabletLandscapeBreakpoint) {
         setFilterDrawerVisible(false);
         event.preventDefault();
-        
+
         // Scroll to the filters and focus first input
         document.querySelector("#filters")?.scrollIntoView();
-        
+
         // Delay focus to allow smooth scroll to complete
         setTimeout(() => {
           const firstFocusable = filtersRef.current?.querySelector<HTMLElement>(
@@ -89,7 +89,7 @@ export function ListWithFiltersLayout<T extends string>({
           );
           firstFocusable?.focus();
         }, 500); // Wait for scroll animation to complete
-        
+
         return;
       }
 


### PR DESCRIPTION
## Summary
- Added functionality to scroll to filters section and focus first input when filter button is clicked at desktop resolutions (tablet-landscape and above)
- Helps users quickly navigate to filters without manually scrolling
- Improves keyboard accessibility by automatically focusing the first filter input

## Implementation Details
- Scrolls smoothly to the filters section using the existing body-level smooth scrolling
- Delays focus by 500ms to avoid interrupting the smooth scroll animation
- Only applies at tablet-landscape breakpoint and above (desktop resolutions)

## Test plan
- [ ] Click filter button at desktop resolution - should smoothly scroll to filters and focus first input
- [ ] Click filter button at mobile/tablet resolution - should open drawer as before
- [ ] Verify smooth scrolling works correctly
- [ ] Verify first input receives focus after scroll completes

🤖 Generated with [Claude Code](https://claude.ai/code)