### PR TITLE
fix: enable cache in test mode with memfs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "globals": "16.3.0",
         "jsdom": "26.1.0",
         "knip": "5.62.0",
+        "memfs": "4.36.0",
         "prettier": "3.6.2",
         "prettier-plugin-astro": "0.14.1",
         "sirv": "3.0.1",
@@ -72,6 +73,7 @@
         "stylelint-order": "7.0.0",
         "typescript": "5.9.2",
         "typescript-eslint": "8.39.1",
+        "unionfs": "4.6.0",
         "vitest": "3.2.4"
       },
       "engines": {
@@ -2808,6 +2810,124 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsonjoy.com/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/buffers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.0.0.tgz",
+      "integrity": "sha512-NDigYR3PHqCnQLXYyoLbnEdzMMvzeiCWo1KOut7Q0CoIqg9tUAPKJ1iq/2nFhc5kZtexzutNY0LFjdwWL3Dw3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/codegen": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+      "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.11.0.tgz",
+      "integrity": "sha512-nLqSTAYwpk+5ZQIoVp7pfd/oSKNWlEdvTq2LzVA4r2wtWZg6v+5u0VgBOaDJuUfNOuw/4Ysq6glN5QKSrOCgrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "^1.1.2",
+        "@jsonjoy.com/buffers": "^1.0.0",
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/json-pointer": "^1.0.1",
+        "@jsonjoy.com/util": "^1.9.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pointer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.1.tgz",
+      "integrity": "sha512-tJpwQfuBuxqZlyoJOSZcqf7OUmiYQ6MiPNmOv4KbZdXE/DdvBSSAwhos0zIlJU/AXxC8XpuO8p08bh2fIl+RKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/util": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+      "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^1.0.0",
+        "@jsonjoy.com/codegen": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/@keyv/serialize": {
@@ -8161,6 +8281,13 @@
         "node": ">=18.3.0"
       }
     },
+    "node_modules/fs-monkey": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
+      "integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -8956,6 +9083,16 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
       }
     },
     "node_modules/iconv-lite": {
@@ -10644,6 +10781,26 @@
       "integrity": "sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/memfs": {
+      "version": "4.36.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.36.0.tgz",
+      "integrity": "sha512-mfBfzGUdoEw5AZwG8E965ej3BbvW2F9LxEWj4uLxF6BEh1dO2N9eS3AGu9S6vfenuQYrVjsbUOOZK7y3vz4vyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/json-pack": "^1.0.3",
+        "@jsonjoy.com/util": "^1.3.0",
+        "tree-dump": "^1.0.1",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      }
     },
     "node_modules/meow": {
       "version": "13.2.0",
@@ -14395,6 +14552,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/thingies": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
+      "integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "^2"
+      }
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -14526,6 +14700,23 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tree-dump": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.3.tgz",
+      "integrity": "sha512-il+Cv80yVHFBwokQSfd4bldvr1Md951DpgAGfmhydt04L+YzHgubm2tQ7zueWDcGENKHq0ZvGFR/hjvNXilHEg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/trim-lines": {
@@ -14909,6 +15100,15 @@
         "css-tree": "^3.0.0",
         "ofetch": "^1.4.1",
         "ohash": "^2.0.0"
+      }
+    },
+    "node_modules/unionfs": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/unionfs/-/unionfs-4.6.0.tgz",
+      "integrity": "sha512-fJAy3gTHjFi5S3TP5EGdjs/OUMFFvI/ady3T8qVuZfkv8Qi8prV/Q8BuFEgODJslhZTT2z2qdD2lGdee9qjEnA==",
+      "dev": true,
+      "dependencies": {
+        "fs-monkey": "^1.0.0"
       }
     },
     "node_modules/unist-util-find-after": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "globals": "16.3.0",
     "jsdom": "26.1.0",
     "knip": "5.62.0",
+    "memfs": "4.36.0",
     "prettier": "3.6.2",
     "prettier-plugin-astro": "0.14.1",
     "sirv": "3.0.1",
@@ -90,6 +91,7 @@
     "stylelint-order": "7.0.0",
     "typescript": "5.9.2",
     "typescript-eslint": "8.39.1",
+    "unionfs": "4.6.0",
     "vitest": "3.2.4"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint  .",
     "lint:fix": "eslint --fix .",
     "lint:spelling": "cspell . --no-progress --show-context --show-suggestions",
-    "lint:spelling:fix": "rm -rf project-words.txt && echo \"# Project Words - DO NOT TOUCH - use npm rum link:spelling:fix instead.\" >> project-words.txt && npm run -s lint:spelling -- --words-only --unique --no-exit-code --no-summary \"**\" | LC_ALL=en_US.UTF-8 sort --ignore-case >> project-words.txt",
+    "lint:spelling:fix": "rm -rf project-words.txt && echo \"# Project Words - DO NOT TOUCH - use npm rum lint:spelling:fix instead.\" >> project-words.txt && npm run -s lint:spelling -- --words-only --unique --no-exit-code --no-summary \"**\" | LC_ALL=en_US.UTF-8 sort --ignore-case >> project-words.txt",
     "preview": "astro preview",
     "start": "astro dev",
     "stylelint": "stylelint \"src/**/*.css\"",

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,4 +1,4 @@
-# Project Words - DO NOT TOUCH - use npm rum link:spelling:fix instead.
+# Project Words - DO NOT TOUCH - use npm rum lint:spelling:fix instead.
 AIDEV
 alltime
 Alltime
@@ -14,7 +14,6 @@ imdb
 kumar
 Loudoun
 lukeed
-memfs
 movielog
 popout
 reviewsmarkdown
@@ -24,6 +23,7 @@ underseen
 Underseen
 unionfs
 unreviewed
+Unreviewed
 viewports
 watchlist
 Watchlist

--- a/project-words.txt
+++ b/project-words.txt
@@ -14,6 +14,7 @@ imdb
 kumar
 Loudoun
 lukeed
+memfs
 movielog
 popout
 reviewsmarkdown
@@ -21,6 +22,7 @@ Ruhl
 Showalter
 underseen
 Underseen
+unionfs
 unreviewed
 viewports
 watchlist

--- a/setupTestCache.ts
+++ b/setupTestCache.ts
@@ -1,0 +1,57 @@
+import { vi } from "vitest";
+import { fs as memFs, vol } from "memfs";
+import { Union } from "unionfs";
+import realFs from "node:fs";
+
+// Create a union filesystem that overlays memfs on top of the real filesystem
+// This allows cache operations to go to memory while other operations go to disk
+const ufs = new Union();
+
+// Add real filesystem first (lower priority)
+ufs.use(realFs);
+
+// Add memfs second (higher priority - will override real fs for matching paths)
+ufs.use(memFs as any);
+
+// Mock node:fs/promises to use our union filesystem
+vi.mock("node:fs/promises", () => {
+  // Create promise versions of the unionfs methods
+  const promisify = (fn: Function) => {
+    return (...args: any[]) =>
+      new Promise((resolve, reject) => {
+        fn(...args, (err: any, result: any) => {
+          if (err) reject(err);
+          else resolve(result);
+        });
+      });
+  };
+
+  return {
+    default: {
+      mkdir: promisify(ufs.mkdir.bind(ufs)),
+      readFile: promisify(ufs.readFile.bind(ufs)),
+      writeFile: promisify(ufs.writeFile.bind(ufs)),
+      access: promisify(ufs.access.bind(ufs)),
+      stat: promisify(ufs.stat.bind(ufs)),
+      readdir: promisify(ufs.readdir.bind(ufs)),
+      unlink: promisify(ufs.unlink.bind(ufs)),
+      rmdir: promisify(ufs.rmdir.bind(ufs)),
+    },
+    mkdir: promisify(ufs.mkdir.bind(ufs)),
+    readFile: promisify(ufs.readFile.bind(ufs)),
+    writeFile: promisify(ufs.writeFile.bind(ufs)),
+    access: promisify(ufs.access.bind(ufs)),
+    stat: promisify(ufs.stat.bind(ufs)),
+    readdir: promisify(ufs.readdir.bind(ufs)),
+    unlink: promisify(ufs.unlink.bind(ufs)),
+    rmdir: promisify(ufs.rmdir.bind(ufs)),
+  };
+});
+
+// Reset memfs volume before each test to clean cache
+beforeEach(() => {
+  vol.reset();
+  // Pre-create the temp directory structure for cache
+  const tmpdir = require("node:os").tmpdir();
+  vol.mkdirSync(tmpdir, { recursive: true });
+});

--- a/src/api/castAndCrew.ts
+++ b/src/api/castAndCrew.ts
@@ -1,3 +1,5 @@
+import { ENABLE_CACHE } from "~/utils/cache";
+
 import {
   allCastAndCrewJson,
   type CastAndCrewMemberJson,
@@ -6,7 +8,7 @@ import { perfLogger } from "./data/utils/performanceLogger";
 
 // Cache at API level - lazy caching for better build performance
 let cachedCastAndCrewJson: CastAndCrewMemberJson[];
-const ENABLE_CACHE = !import.meta.env.DEV;
+// ENABLE_CACHE is now imported from utils/cache
 
 export type CastAndCrewMember = CastAndCrewMemberJson & {};
 

--- a/src/api/collections.ts
+++ b/src/api/collections.ts
@@ -6,6 +6,8 @@ import remarkRehype from "remark-rehype";
 import smartypants from "remark-smartypants";
 import strip from "strip-markdown";
 
+import { ENABLE_CACHE } from "~/utils/cache";
+
 import {
   allCollectionsJson,
   type CollectionJson,
@@ -16,7 +18,7 @@ import { rootAsSpan } from "./utils/markdown/rootAsSpan";
 
 // Cache at API level - lazy caching for better build performance
 let cachedCollectionsJson: CollectionJson[];
-const ENABLE_CACHE = !import.meta.env.DEV;
+// ENABLE_CACHE is now imported from utils/cache
 
 export type Collection = CollectionJson & {};
 

--- a/src/api/reviews.ts
+++ b/src/api/reviews.ts
@@ -6,6 +6,7 @@ import remarkRehype from "remark-rehype";
 import smartypants from "remark-smartypants";
 import strip from "strip-markdown";
 
+import { ENABLE_CACHE } from "~/utils/cache";
 import { collator } from "~/utils/collator";
 
 import type { ReviewedTitleJson } from "./data/reviewedTitlesJson";
@@ -29,8 +30,7 @@ let cachedReviewedTitlesJson: ReviewedTitleJson[];
 let cachedReviews: Reviews;
 const cachedExcerptHtml: Map<string, string> = new Map();
 
-// Enable caching during builds but not in dev mode
-const ENABLE_CACHE = !import.meta.env.DEV;
+// ENABLE_CACHE is now imported from utils/cache
 
 export type Review = Omit<MarkdownReview, "date"> & ReviewedTitleJson;
 

--- a/src/utils/cache.spec.ts
+++ b/src/utils/cache.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createCacheConfig,
+  createCacheKey,
+  ENABLE_CACHE,
+  ensureCacheDir,
+  getCachedItem,
+  saveCachedItem,
+} from "./cache";
+
+describe("cache", () => {
+  describe("ENABLE_CACHE", () => {
+    it("should be enabled in test mode", () => {
+      expect(ENABLE_CACHE).toBe(true);
+    });
+  });
+
+  describe("caching operations", () => {
+    it("should save and retrieve cached items", async () => {
+      const config = createCacheConfig("test-cache");
+      const cacheKey = createCacheKey("test-key");
+      const testContent = "test content";
+
+      // Ensure cache directory exists
+      await ensureCacheDir(config.cacheDir);
+
+      // Save item to cache
+      await saveCachedItem(
+        config.cacheDir,
+        cacheKey,
+        "txt",
+        testContent,
+      );
+
+      // Retrieve item from cache
+      const cachedContent = await getCachedItem<string>(
+        config.cacheDir,
+        cacheKey,
+        "txt",
+        false,
+        config.debugCache,
+        "test cache item",
+      );
+
+      expect(cachedContent).toBe(testContent);
+    });
+
+    it("should return undefined for non-existent cache items", async () => {
+      const config = createCacheConfig("test-cache");
+      const cacheKey = createCacheKey("non-existent-key");
+
+      const cachedContent = await getCachedItem<string>(
+        config.cacheDir,
+        cacheKey,
+        "txt",
+        false,
+        config.debugCache,
+        "non-existent item",
+      );
+
+      expect(cachedContent).toBeUndefined();
+    });
+
+    it("should handle binary data", async () => {
+      const config = createCacheConfig("test-cache");
+      const cacheKey = createCacheKey("binary-key");
+      const testContent = new Uint8Array([1, 2, 3, 4, 5]);
+
+      // Ensure cache directory exists
+      await ensureCacheDir(config.cacheDir);
+
+      // Save binary item to cache
+      await saveCachedItem(
+        config.cacheDir,
+        cacheKey,
+        "bin",
+        testContent,
+      );
+
+      // Retrieve binary item from cache
+      const cachedContent = await getCachedItem<Buffer>(
+        config.cacheDir,
+        cacheKey,
+        "bin",
+        true,
+        config.debugCache,
+        "binary cache item",
+      );
+
+      // Convert Buffer to Uint8Array for comparison
+      expect(new Uint8Array(cachedContent!)).toEqual(testContent);
+    });
+  });
+
+  describe("createCacheConfig", () => {
+    it("should create config with cache enabled in test mode", () => {
+      const config = createCacheConfig("test");
+      expect(config.cacheDir).toContain(".cache/test");
+      expect(config.enableCache).toBe(true);
+    });
+  });
+});

--- a/src/utils/cache.spec.ts
+++ b/src/utils/cache.spec.ts
@@ -26,12 +26,7 @@ describe("cache", () => {
       await ensureCacheDir(config.cacheDir);
 
       // Save item to cache
-      await saveCachedItem(
-        config.cacheDir,
-        cacheKey,
-        "txt",
-        testContent,
-      );
+      await saveCachedItem(config.cacheDir, cacheKey, "txt", testContent);
 
       // Retrieve item from cache
       const cachedContent = await getCachedItem<string>(
@@ -71,12 +66,7 @@ describe("cache", () => {
       await ensureCacheDir(config.cacheDir);
 
       // Save binary item to cache
-      await saveCachedItem(
-        config.cacheDir,
-        cacheKey,
-        "bin",
-        testContent,
-      );
+      await saveCachedItem(config.cacheDir, cacheKey, "bin", testContent);
 
       // Retrieve binary item from cache
       const cachedContent = await getCachedItem<Buffer>(

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
-import { tmpdir } from "node:os";
 import path from "node:path";
 
 type CacheConfig = {

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -9,17 +9,26 @@ type CacheConfig = {
   enableCache: boolean;
 };
 
-export function createCacheConfig(
-  name: string,
-  isTest: boolean = import.meta.env.MODE === "test",
-  isDev: boolean = import.meta.env.DEV,
-): CacheConfig {
+/**
+ * Determines if caching should be enabled based on environment
+ * - Disabled in development mode (DEV=true)
+ * - Enabled in test mode (MODE=test) to test cache behavior
+ * - Enabled in production builds
+ */
+export const ENABLE_CACHE = (() => {
+  // Enable caching in test mode to test cache behavior
+  if (import.meta.env.MODE === "test") {
+    return true;
+  }
+  // Disable in dev mode
+  return !import.meta.env.DEV;
+})();
+
+export function createCacheConfig(name: string): CacheConfig {
   return {
-    cacheDir: isTest
-      ? path.join(tmpdir(), `${name}-test-cache`)
-      : path.join(process.cwd(), ".cache", name),
+    cacheDir: path.join(process.cwd(), ".cache", name),
     debugCache: process.env.DEBUG_CACHE === "true",
-    enableCache: !isDev,
+    enableCache: ENABLE_CACHE,
   };
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,7 @@ export default getViteConfig({
           environment: "node",
           include: ["src/api/**/*.spec.ts"],
           name: "api-node",
+          setupFiles: ["setupTests.ts", "setupTestCache.ts"],
         },
       },
       {
@@ -24,6 +25,7 @@ export default getViteConfig({
           environment: "node",
           include: ["src/pages/**/*.spec.ts"],
           name: "pages-node",
+          setupFiles: ["setupTests.ts", "setupTestCache.ts"],
         },
       },
       {
@@ -48,6 +50,15 @@ export default getViteConfig({
           environment: "node",
           include: ["src/layouts/**/*.spec.ts"],
           name: "layouts-node",
+        },
+      },
+      {
+        extends: true,
+        test: {
+          environment: "node",
+          include: ["src/utils/**/*.spec.ts"],
+          name: "utils-node",
+          setupFiles: ["setupTests.ts", "setupTestCache.ts"],
         },
       },
     ],


### PR DESCRIPTION
## Summary
- Centralized cache enable/disable logic in `utils/cache.ts`
- Enabled cache in test mode to properly test cache behavior
- Used unionfs to overlay memfs for cache operations in tests while keeping real filesystem for other operations

## Changes
- Export `ENABLE_CACHE` constant from `utils/cache.ts` that properly detects test mode using `import.meta.env.MODE === "test"`
- Updated all cache consumers (`reviews.ts`, `collections.ts`, `castAndCrew.ts`) to import from centralized location
- Set up unionfs with memfs for test environment to handle cache operations in memory
- Added comprehensive cache unit tests
- Simplified `createCacheConfig` by removing `isTest` parameter

## Test plan
- [x] All existing tests pass
- [x] New cache unit tests pass
- [x] Cache is properly enabled in test mode
- [x] Cache operations use in-memory storage in tests (no filesystem side effects)
- [x] Lint checks pass
- [x] Format checks pass
- [x] Type checks pass
- [x] Knip checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)