### PR TITLE
fix: MultiSelect dropdown opens upward when insufficient space below

### DIFF
--- a/src/components/MultiSelectField.spec.tsx
+++ b/src/components/MultiSelectField.spec.tsx
@@ -13,28 +13,37 @@ describe("MultiSelectField", () => {
   const defaultProps = {
     label: "Test Label",
     onChange: vi.fn(),
-    options: ["Option 1", "Option 2", "Option 3", "Option 4", "Option 5", "Option 6", "Option 7", "Option 8"],
+    options: [
+      "Option 1",
+      "Option 2",
+      "Option 3",
+      "Option 4",
+      "Option 5",
+      "Option 6",
+      "Option 7",
+      "Option 8",
+    ],
   };
 
   it("renders with label", ({ expect }) => {
     render(<MultiSelectField {...defaultProps} />);
-    
+
     expect(screen.getByLabelText("Test Label")).toBeInTheDocument();
   });
 
   it("shows placeholder when no options selected", ({ expect }) => {
     render(<MultiSelectField {...defaultProps} />);
-    
+
     expect(screen.getByText("Select...")).toBeInTheDocument();
   });
 
   it("opens dropdown when clicked", async ({ expect }) => {
     const user = userEvent.setup();
     render(<MultiSelectField {...defaultProps} />);
-    
+
     const button = screen.getByRole("button", { name: "Test Label" });
     await user.click(button);
-    
+
     expect(screen.getByRole("listbox")).toBeInTheDocument();
   });
 
@@ -44,17 +53,17 @@ describe("MultiSelectField", () => {
       <div>
         <MultiSelectField {...defaultProps} />
         <button type="button">Outside</button>
-      </div>
+      </div>,
     );
-    
+
     // Open dropdown
     const button = screen.getByRole("button", { name: "Test Label" });
     await user.click(button);
     expect(screen.getByRole("listbox")).toBeInTheDocument();
-    
+
     // Click outside
     await user.click(screen.getByRole("button", { name: "Outside" }));
-    
+
     await waitFor(() => {
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     });
@@ -64,12 +73,12 @@ describe("MultiSelectField", () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
     render(<MultiSelectField {...defaultProps} onChange={onChange} />);
-    
+
     const button = screen.getByRole("button", { name: "Test Label" });
     await user.click(button);
-    
+
     await user.click(screen.getByText("Option 1"));
-    
+
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledWith(["Option 1"]);
     });
@@ -79,34 +88,40 @@ describe("MultiSelectField", () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
     render(<MultiSelectField {...defaultProps} onChange={onChange} />);
-    
+
     // Select an option first
     const button = screen.getByRole("button", { name: "Test Label" });
     await user.click(button);
     await user.click(screen.getByText("Option 1"));
-    
+
     // Remove the option
-    const removeButton = screen.getByRole("button", { name: "Remove Option 1" });
+    const removeButton = screen.getByRole("button", {
+      name: "Remove Option 1",
+    });
     await user.click(removeButton);
-    
+
     expect(onChange).toHaveBeenLastCalledWith([]);
   });
 
-  it("clears all selections when clear button is clicked", async ({ expect }) => {
+  it("clears all selections when clear button is clicked", async ({
+    expect,
+  }) => {
     const onChange = vi.fn();
     const user = userEvent.setup();
     render(<MultiSelectField {...defaultProps} onChange={onChange} />);
-    
+
     // Select multiple options
     const button = screen.getByRole("button", { name: "Test Label" });
     await user.click(button);
     await user.click(screen.getByText("Option 1"));
     await user.click(screen.getByText("Option 2"));
-    
+
     // Clear all
-    const clearButton = screen.getByRole("button", { name: "Clear all selections" });
+    const clearButton = screen.getByRole("button", {
+      name: "Clear all selections",
+    });
     await user.click(clearButton);
-    
+
     expect(onChange).toHaveBeenLastCalledWith([]);
   });
 
@@ -114,33 +129,33 @@ describe("MultiSelectField", () => {
     it("opens dropdown with Enter key", async ({ expect }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       button.focus();
       await user.keyboard("{Enter}");
-      
+
       expect(screen.getByRole("listbox")).toBeInTheDocument();
     });
 
     it("opens dropdown with Space key", async ({ expect }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       button.focus();
       await user.keyboard(" ");
-      
+
       expect(screen.getByRole("listbox")).toBeInTheDocument();
     });
 
     it("opens dropdown with ArrowDown key", async ({ expect }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       button.focus();
       await user.keyboard("{ArrowDown}");
-      
+
       expect(screen.getByRole("listbox")).toBeInTheDocument();
       // Should also highlight first item
       const options = screen.getAllByRole("option");
@@ -150,11 +165,11 @@ describe("MultiSelectField", () => {
     it("opens dropdown with ArrowUp key", async ({ expect }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       button.focus();
       await user.keyboard("{ArrowUp}");
-      
+
       expect(screen.getByRole("listbox")).toBeInTheDocument();
       // Should also highlight first item
       const options = screen.getAllByRole("option");
@@ -164,21 +179,21 @@ describe("MultiSelectField", () => {
     it("navigates options with arrow keys", async ({ expect }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       // Navigate down
       await user.keyboard("{ArrowDown}");
-      
+
       // Check that first option is highlighted by looking for the bg-stripe class
       const options = screen.getAllByRole("option");
       expect(options[0].className).toContain("bg-stripe");
-      
+
       // Navigate down again
       await user.keyboard("{ArrowDown}");
       expect(options[1].className).toContain("bg-stripe");
-      
+
       // Navigate up
       await user.keyboard("{ArrowUp}");
       expect(options[0].className).toContain("bg-stripe");
@@ -187,87 +202,93 @@ describe("MultiSelectField", () => {
     it("navigates to last option with End key", async ({ expect }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       // Press End to go to last option
       await user.keyboard("{End}");
-      
+
       const options = screen.getAllByRole("option");
-      expect(options[options.length - 1].className).toContain("bg-stripe");
+      expect(options.at(-1)?.className).toContain("bg-stripe");
     });
 
     it("navigates to first option with Home key", async ({ expect }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       // Navigate down a few times first
       await user.keyboard("{ArrowDown}");
       await user.keyboard("{ArrowDown}");
       await user.keyboard("{ArrowDown}");
-      
+
       // Press Home to go back to first option
       await user.keyboard("{Home}");
-      
+
       const options = screen.getAllByRole("option");
       expect(options[0].className).toContain("bg-stripe");
     });
 
-    it("doesn't navigate past last option with ArrowDown", async ({ expect }) => {
+    it("doesn't navigate past last option with ArrowDown", async ({
+      expect,
+    }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       // Navigate to last option
       await user.keyboard("{End}");
-      
+
       // Try to go past the last option
       await user.keyboard("{ArrowDown}");
-      
+
       const options = screen.getAllByRole("option");
       // Should still be on last option
-      expect(options[options.length - 1].className).toContain("bg-stripe");
+      expect(options.at(-1)?.className).toContain("bg-stripe");
     });
 
-    it("doesn't navigate before first option with ArrowUp", async ({ expect }) => {
+    it("doesn't navigate before first option with ArrowUp", async ({
+      expect,
+    }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       // Already at first option, try to go up
       await user.keyboard("{ArrowUp}");
-      
+
       const options = screen.getAllByRole("option");
       // Should still be on first option
       expect(options[0].className).toContain("bg-stripe");
     });
 
-    it("selects option with mouse click after keyboard navigation", async ({ expect }) => {
+    it("selects option with mouse click after keyboard navigation", async ({
+      expect,
+    }) => {
       const onChange = vi.fn();
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} onChange={onChange} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       // Navigate to third option with keyboard
       const listbox = screen.getByRole("listbox");
       listbox.focus();
       await user.keyboard("{ArrowDown}");
       await user.keyboard("{ArrowDown}");
-      
+
       // Click on the highlighted option
       const thirdOption = screen.getByText("Option 3");
       await user.click(thirdOption);
-      
+
       await waitFor(() => {
         expect(onChange).toHaveBeenCalledWith(["Option 3"]);
       });
@@ -279,18 +300,18 @@ describe("MultiSelectField", () => {
         <div>
           <MultiSelectField {...defaultProps} />
           <button type="button">Next Element</button>
-        </div>
+        </div>,
       );
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
       expect(screen.getByRole("listbox")).toBeInTheDocument();
-      
+
       // Focus the listbox and tab away
       const listbox = screen.getByRole("listbox");
       listbox.focus();
       await user.keyboard("{Tab}");
-      
+
       await waitFor(() => {
         expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
       });
@@ -299,47 +320,49 @@ describe("MultiSelectField", () => {
     it("closes dropdown with Escape key", async ({ expect }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
       expect(screen.getByRole("listbox")).toBeInTheDocument();
-      
+
       // Focus the listbox and press Escape
       const listbox = screen.getByRole("listbox");
       listbox.focus();
       await user.keyboard("{Escape}");
-      
+
       await waitFor(() => {
         expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
       });
-      
+
       // Focus should return to button
       expect(button).toHaveFocus();
     });
 
-    it("maintains dropdown open after selecting an option", async ({ expect }) => {
+    it("maintains dropdown open after selecting an option", async ({
+      expect,
+    }) => {
       const onChange = vi.fn();
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} onChange={onChange} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       // Select an option
       await user.click(screen.getByText("Option 2"));
-      
+
       await waitFor(() => {
         expect(onChange).toHaveBeenCalledWith(["Option 2"]);
       });
-      
+
       // Dropdown should still be open
       expect(screen.getByRole("listbox")).toBeInTheDocument();
-      
+
       // Option 2 should not be in the available options anymore
       const options = screen.getAllByRole("option");
       expect(options).toHaveLength(7);
       // Verify Option 2 is not among the options
-      const optionTexts = options.map(opt => opt.textContent);
+      const optionTexts = options.map((opt) => opt.textContent);
       expect(optionTexts).not.toContain("Option 2");
     });
 
@@ -347,68 +370,76 @@ describe("MultiSelectField", () => {
       const onChange = vi.fn();
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} onChange={onChange} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       // Initially should have 8 options
       let options = screen.getAllByRole("option");
       expect(options).toHaveLength(8);
-      
+
       // Select Option 1
       await user.click(screen.getByText("Option 1"));
-      
+
       // Should now have 7 options
       options = screen.getAllByRole("option");
       expect(options).toHaveLength(7);
-      
+
       // Option 1 should not be in the list
-      expect(screen.queryByRole("option", { name: "Option 1" })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("option", { name: "Option 1" }),
+      ).not.toBeInTheDocument();
     });
 
-    it("handles keyboard navigation when no options available", async ({ expect }) => {
+    it("handles keyboard navigation when no options available", async ({
+      expect,
+    }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} options={[]} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       // Should show no options available message
       expect(screen.getByText("No options available")).toBeInTheDocument();
-      
+
       // Arrow keys shouldn't cause errors
       await user.keyboard("{ArrowDown}");
       await user.keyboard("{ArrowUp}");
       await user.keyboard("{Home}");
       await user.keyboard("{End}");
-      
+
       // Message should still be there
       expect(screen.getByText("No options available")).toBeInTheDocument();
     });
   });
 
   describe("Dropdown Positioning", () => {
-    it("positions dropdown below button when sufficient space", ({ expect }) => {
+    it("positions dropdown below button when sufficient space", ({
+      expect,
+    }) => {
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       act(() => {
         button.click();
       });
-      
+
       const dropdown = screen.getByRole("listbox").parentElement;
       expect(dropdown?.className).toContain("top-full");
     });
 
-    it("calculates dropdown height based on available options", async ({ expect }) => {
+    it("calculates dropdown height based on available options", async ({
+      expect,
+    }) => {
       const user = userEvent.setup();
       const fewOptions = ["Option 1", "Option 2"];
-      
+
       render(<MultiSelectField {...defaultProps} options={fewOptions} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       const dropdown = screen.getByRole("listbox").parentElement;
       // With 2 options and MIN_VISIBLE_ITEMS = 3, should show space for 3 items
       expect(dropdown?.style.maxHeight).toBe("120px"); // 3 * 40px
@@ -416,13 +447,16 @@ describe("MultiSelectField", () => {
 
     it("limits dropdown height to MAX_VISIBLE_ITEMS", async ({ expect }) => {
       const user = userEvent.setup();
-      const manyOptions = Array.from({ length: 20 }, (_, i) => `Option ${i + 1}`);
-      
+      const manyOptions = Array.from(
+        { length: 20 },
+        (_, i) => `Option ${i + 1}`,
+      );
+
       render(<MultiSelectField {...defaultProps} options={manyOptions} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       const dropdown = screen.getByRole("listbox").parentElement;
       // Should be limited to MAX_VISIBLE_ITEMS = 7
       expect(dropdown?.style.maxHeight).toBe("280px"); // 7 * 40px
@@ -430,16 +464,16 @@ describe("MultiSelectField", () => {
 
     it("recalculates position when options change", async ({ expect }) => {
       const user = userEvent.setup();
-      const { rerender } = render(<MultiSelectField {...defaultProps} />);
-      
+      render(<MultiSelectField {...defaultProps} />);
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       // Select some options to reduce available options
       await user.click(screen.getByText("Option 1"));
       await user.click(screen.getByText("Option 2"));
       await user.click(screen.getByText("Option 3"));
-      
+
       // Dropdown should recalculate height
       const dropdown = screen.getByRole("listbox").parentElement;
       // 5 remaining options, should show 5 * 40px
@@ -453,14 +487,14 @@ describe("MultiSelectField", () => {
         <fieldset>
           <legend>Test Fieldset</legend>
           <MultiSelectField {...defaultProps} />
-        </fieldset>
+        </fieldset>,
       );
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       act(() => {
         button.click();
       });
-      
+
       // Should find and use fieldset parent for calculations
       expect(screen.getByRole("listbox")).toBeInTheDocument();
     });
@@ -469,14 +503,14 @@ describe("MultiSelectField", () => {
       render(
         <div>
           <MultiSelectField {...defaultProps} />
-        </div>
+        </div>,
       );
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       act(() => {
         button.click();
       });
-      
+
       // Should still work without fieldset
       expect(screen.getByRole("listbox")).toBeInTheDocument();
     });
@@ -484,33 +518,42 @@ describe("MultiSelectField", () => {
 
   describe("Scroll and Resize Handlers", () => {
     it("adds resize listener when dropdown is open", async ({ expect }) => {
-      const addEventListenerSpy = vi.spyOn(window, "addEventListener");
+      const addEventListenerSpy = vi.spyOn(globalThis, "addEventListener");
       const user = userEvent.setup();
-      
+
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
-      expect(addEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
-      
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        "resize",
+        expect.any(Function),
+      );
+
       addEventListenerSpy.mockRestore();
     });
 
     it("removes listeners when component unmounts", async ({ expect }) => {
-      const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+      const removeEventListenerSpy = vi.spyOn(
+        globalThis,
+        "removeEventListener",
+      );
       const user = userEvent.setup();
-      
+
       const { unmount } = render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       // Unmount the component
       unmount();
-      
-      expect(removeEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
-      
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        "resize",
+        expect.any(Function),
+      );
+
       removeEventListenerSpy.mockRestore();
     });
   });
@@ -519,18 +562,18 @@ describe("MultiSelectField", () => {
     it("has proper ARIA attributes", async ({ expect }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
-      
+
       // Closed state
       expect(button).toHaveAttribute("aria-expanded", "false");
       expect(button).toHaveAttribute("aria-haspopup", "listbox");
-      
+
       // Open state
       await user.click(button);
       expect(button).toHaveAttribute("aria-expanded", "true");
       expect(button).toHaveAttribute("aria-controls", expect.any(String));
-      
+
       const listbox = screen.getByRole("listbox");
       expect(listbox).toHaveAttribute("aria-multiselectable", "true");
       expect(listbox).toHaveAttribute("aria-labelledby", expect.any(String));
@@ -539,13 +582,13 @@ describe("MultiSelectField", () => {
     it("manages focus correctly", async ({ expect }) => {
       const user = userEvent.setup();
       render(<MultiSelectField {...defaultProps} />);
-      
+
       const button = screen.getByRole("button", { name: "Test Label" });
       await user.click(button);
-      
+
       // Select an option
       await user.click(screen.getByText("Option 1"));
-      
+
       // Focus should return to button after selection
       await waitFor(() => {
         expect(button).toHaveFocus();

--- a/src/components/MultiSelectField.spec.tsx
+++ b/src/components/MultiSelectField.spec.tsx
@@ -1,0 +1,349 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { userEvent } from "@testing-library/user-event";
+import { describe, it, vi } from "vitest";
+
+import { MultiSelectField } from "./MultiSelectField";
+
+// Mock scrollIntoView for all tests
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = vi.fn();
+}
+
+describe("MultiSelectField", () => {
+  const defaultProps = {
+    label: "Test Label",
+    onChange: vi.fn(),
+    options: ["Option 1", "Option 2", "Option 3", "Option 4", "Option 5", "Option 6", "Option 7", "Option 8"],
+  };
+
+  it("renders with label", ({ expect }) => {
+    render(<MultiSelectField {...defaultProps} />);
+    
+    expect(screen.getByLabelText("Test Label")).toBeInTheDocument();
+  });
+
+  it("shows placeholder when no options selected", ({ expect }) => {
+    render(<MultiSelectField {...defaultProps} />);
+    
+    expect(screen.getByText("Select...")).toBeInTheDocument();
+  });
+
+  it("opens dropdown when clicked", async ({ expect }) => {
+    const user = userEvent.setup();
+    render(<MultiSelectField {...defaultProps} />);
+    
+    const button = screen.getByRole("button", { name: "Test Label" });
+    await user.click(button);
+    
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+  });
+
+  it("closes dropdown when clicking outside", async ({ expect }) => {
+    const user = userEvent.setup();
+    render(
+      <div>
+        <MultiSelectField {...defaultProps} />
+        <button type="button">Outside</button>
+      </div>
+    );
+    
+    // Open dropdown
+    const button = screen.getByRole("button", { name: "Test Label" });
+    await user.click(button);
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    
+    // Click outside
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+    
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    });
+  });
+
+  it("selects an option when clicked", async ({ expect }) => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<MultiSelectField {...defaultProps} onChange={onChange} />);
+    
+    const button = screen.getByRole("button", { name: "Test Label" });
+    await user.click(button);
+    
+    await user.click(screen.getByText("Option 1"));
+    
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(["Option 1"]);
+    });
+  });
+
+  it("removes selected option when X is clicked", async ({ expect }) => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<MultiSelectField {...defaultProps} onChange={onChange} />);
+    
+    // Select an option first
+    const button = screen.getByRole("button", { name: "Test Label" });
+    await user.click(button);
+    await user.click(screen.getByText("Option 1"));
+    
+    // Remove the option
+    const removeButton = screen.getByRole("button", { name: "Remove Option 1" });
+    await user.click(removeButton);
+    
+    expect(onChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it("clears all selections when clear button is clicked", async ({ expect }) => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<MultiSelectField {...defaultProps} onChange={onChange} />);
+    
+    // Select multiple options
+    const button = screen.getByRole("button", { name: "Test Label" });
+    await user.click(button);
+    await user.click(screen.getByText("Option 1"));
+    await user.click(screen.getByText("Option 2"));
+    
+    // Clear all
+    const clearButton = screen.getByRole("button", { name: "Clear all selections" });
+    await user.click(clearButton);
+    
+    expect(onChange).toHaveBeenLastCalledWith([]);
+  });
+
+  describe("Keyboard Navigation", () => {
+    it("opens dropdown with Enter key", async ({ expect }) => {
+      const user = userEvent.setup();
+      render(<MultiSelectField {...defaultProps} />);
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      button.focus();
+      await user.keyboard("{Enter}");
+      
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    it("navigates options with arrow keys", async ({ expect }) => {
+      const user = userEvent.setup();
+      render(<MultiSelectField {...defaultProps} />);
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      await user.click(button);
+      
+      // Navigate down
+      await user.keyboard("{ArrowDown}");
+      
+      // Check that first option is highlighted by looking for the bg-stripe class
+      const options = screen.getAllByRole("option");
+      expect(options[0].className).toContain("bg-stripe");
+      
+      // Navigate down again
+      await user.keyboard("{ArrowDown}");
+      expect(options[1].className).toContain("bg-stripe");
+      
+      // Navigate up
+      await user.keyboard("{ArrowUp}");
+      expect(options[0].className).toContain("bg-stripe");
+    });
+
+    it("selects option with click", async ({ expect }) => {
+      const onChange = vi.fn();
+      const user = userEvent.setup();
+      render(<MultiSelectField {...defaultProps} onChange={onChange} />);
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      await user.click(button);
+      
+      // Click on the first option
+      const firstOption = screen.getByText("Option 1");
+      await user.click(firstOption);
+      
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(["Option 1"]);
+      });
+    });
+
+    it("closes dropdown with Escape key", async ({ expect }) => {
+      const user = userEvent.setup();
+      render(<MultiSelectField {...defaultProps} />);
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      await user.click(button);
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+      
+      // Focus the listbox and press Escape
+      const listbox = screen.getByRole("listbox");
+      listbox.focus();
+      await user.keyboard("{Escape}");
+      
+      await waitFor(() => {
+        expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Dropdown Positioning", () => {
+    it("positions dropdown below button when sufficient space", ({ expect }) => {
+      render(<MultiSelectField {...defaultProps} />);
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      act(() => {
+        button.click();
+      });
+      
+      const dropdown = screen.getByRole("listbox").parentElement;
+      expect(dropdown?.className).toContain("top-full");
+    });
+
+    it("calculates dropdown height based on available options", async ({ expect }) => {
+      const user = userEvent.setup();
+      const fewOptions = ["Option 1", "Option 2"];
+      
+      render(<MultiSelectField {...defaultProps} options={fewOptions} />);
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      await user.click(button);
+      
+      const dropdown = screen.getByRole("listbox").parentElement;
+      // With 2 options and MIN_VISIBLE_ITEMS = 3, should show space for 3 items
+      expect(dropdown?.style.maxHeight).toBe("120px"); // 3 * 40px
+    });
+
+    it("limits dropdown height to MAX_VISIBLE_ITEMS", async ({ expect }) => {
+      const user = userEvent.setup();
+      const manyOptions = Array.from({ length: 20 }, (_, i) => `Option ${i + 1}`);
+      
+      render(<MultiSelectField {...defaultProps} options={manyOptions} />);
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      await user.click(button);
+      
+      const dropdown = screen.getByRole("listbox").parentElement;
+      // Should be limited to MAX_VISIBLE_ITEMS = 7
+      expect(dropdown?.style.maxHeight).toBe("280px"); // 7 * 40px
+    });
+
+    it("recalculates position when options change", async ({ expect }) => {
+      const user = userEvent.setup();
+      const { rerender } = render(<MultiSelectField {...defaultProps} />);
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      await user.click(button);
+      
+      // Select some options to reduce available options
+      await user.click(screen.getByText("Option 1"));
+      await user.click(screen.getByText("Option 2"));
+      await user.click(screen.getByText("Option 3"));
+      
+      // Dropdown should recalculate height
+      const dropdown = screen.getByRole("listbox").parentElement;
+      // 5 remaining options, should show 5 * 40px
+      expect(dropdown?.style.maxHeight).toBe("200px");
+    });
+  });
+
+  describe("Fieldset Parent Detection", () => {
+    it("uses fieldset boundaries when inside fieldset", ({ expect }) => {
+      render(
+        <fieldset>
+          <legend>Test Fieldset</legend>
+          <MultiSelectField {...defaultProps} />
+        </fieldset>
+      );
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      act(() => {
+        button.click();
+      });
+      
+      // Should find and use fieldset parent for calculations
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    it("falls back to viewport when no fieldset parent", ({ expect }) => {
+      render(
+        <div>
+          <MultiSelectField {...defaultProps} />
+        </div>
+      );
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      act(() => {
+        button.click();
+      });
+      
+      // Should still work without fieldset
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+  });
+
+  describe("Scroll and Resize Handlers", () => {
+    it("adds resize listener when dropdown is open", async ({ expect }) => {
+      const addEventListenerSpy = vi.spyOn(window, "addEventListener");
+      const user = userEvent.setup();
+      
+      render(<MultiSelectField {...defaultProps} />);
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      await user.click(button);
+      
+      expect(addEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
+      
+      addEventListenerSpy.mockRestore();
+    });
+
+    it("removes listeners when component unmounts", async ({ expect }) => {
+      const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+      const user = userEvent.setup();
+      
+      const { unmount } = render(<MultiSelectField {...defaultProps} />);
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      await user.click(button);
+      
+      // Unmount the component
+      unmount();
+      
+      expect(removeEventListenerSpy).toHaveBeenCalledWith("resize", expect.any(Function));
+      
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("has proper ARIA attributes", async ({ expect }) => {
+      const user = userEvent.setup();
+      render(<MultiSelectField {...defaultProps} />);
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      
+      // Closed state
+      expect(button).toHaveAttribute("aria-expanded", "false");
+      expect(button).toHaveAttribute("aria-haspopup", "listbox");
+      
+      // Open state
+      await user.click(button);
+      expect(button).toHaveAttribute("aria-expanded", "true");
+      expect(button).toHaveAttribute("aria-controls", expect.any(String));
+      
+      const listbox = screen.getByRole("listbox");
+      expect(listbox).toHaveAttribute("aria-multiselectable", "true");
+      expect(listbox).toHaveAttribute("aria-labelledby", expect.any(String));
+    });
+
+    it("manages focus correctly", async ({ expect }) => {
+      const user = userEvent.setup();
+      render(<MultiSelectField {...defaultProps} />);
+      
+      const button = screen.getByRole("button", { name: "Test Label" });
+      await user.click(button);
+      
+      // Select an option
+      await user.click(screen.getByText("Option 1"));
+      
+      // Focus should return to button after selection
+      await waitFor(() => {
+        expect(button).toHaveFocus();
+      });
+    });
+  });
+});

--- a/src/components/MultiSelectField.tsx
+++ b/src/components/MultiSelectField.tsx
@@ -13,7 +13,7 @@ const SCROLL_DELAY_MS = 50;
 
 // Dropdown sizing based on items
 const ITEM_HEIGHT = 40; // Approximate height of each dropdown item in pixels
-const MIN_VISIBLE_ITEMS = 4;
+const MIN_VISIBLE_ITEMS = 3;
 const MAX_VISIBLE_ITEMS = 7;
 
 // Helper to find the nearest fieldset parent
@@ -84,8 +84,7 @@ const determineDropdownLayout = (
 ) => {
   // Calculate heights based on number of items
   const minDropdownHeight = MIN_VISIBLE_ITEMS * ITEM_HEIGHT;
-  const maxDropdownHeight = Math.min(MAX_VISIBLE_ITEMS, itemCount) * ITEM_HEIGHT;
-  
+
   // Check if we can fit minimum items below
   if (effectiveSpaceBelow < minDropdownHeight) {
     // Can't fit minimum below, try above
@@ -94,7 +93,7 @@ const determineDropdownLayout = (
       const itemsThatFit = Math.min(
         Math.floor(effectiveSpaceAbove / ITEM_HEIGHT),
         MAX_VISIBLE_ITEMS,
-        itemCount
+        itemCount,
       );
       const height = Math.max(MIN_VISIBLE_ITEMS, itemsThatFit) * ITEM_HEIGHT;
       return { height: `${height}px`, position: "above" as const };
@@ -108,7 +107,7 @@ const determineDropdownLayout = (
     const itemsThatFit = Math.min(
       Math.floor(effectiveSpaceBelow / ITEM_HEIGHT),
       MAX_VISIBLE_ITEMS,
-      itemCount
+      itemCount,
     );
     const height = Math.max(MIN_VISIBLE_ITEMS, itemsThatFit) * ITEM_HEIGHT;
     return { height: `${height}px`, position: "below" as const };
@@ -291,14 +290,14 @@ export function MultiSelectField({
 
     const buttonRect = buttonRef.current.getBoundingClientRect();
     const fieldsetParent = findFieldsetParent(buttonRef.current);
-    
+
     const { effectiveSpaceAbove, effectiveSpaceBelow } =
       calculateAvailableSpace(buttonRect, fieldsetParent);
 
     const { height, position } = determineDropdownLayout(
       effectiveSpaceAbove,
       effectiveSpaceBelow,
-      availableOptions.length
+      availableOptions.length,
     );
 
     setDropdownPosition(position);

--- a/src/components/MultiSelectField.tsx
+++ b/src/components/MultiSelectField.tsx
@@ -11,8 +11,6 @@ const SPACE_BUFFER_ABOVE = 20;
 const SPACE_BUFFER_BELOW = 10;
 const MIN_DROPDOWN_HEIGHT = 120;
 const MAX_DROPDOWN_HEIGHT = 300;
-const MOBILE_FOOTER_BUFFER = 100;
-const DESKTOP_FOOTER_BUFFER = 20;
 const MIN_FALLBACK_HEIGHT = 80;
 const SCROLL_DELAY_MS = 50;
 
@@ -41,11 +39,9 @@ const findScrollableContainer = (
 const calculateAvailableSpace = (
   buttonRect: DOMRect,
   scrollableContainer: HTMLElement | undefined,
-  isMobileDrawer: boolean,
 ) => {
   let effectiveSpaceBelow: number;
   let effectiveSpaceAbove: number;
-  const viewportHeight = window.innerHeight;
 
   if (scrollableContainer) {
     // We're inside a scrollable container
@@ -71,14 +67,9 @@ const calculateAvailableSpace = (
     }
   } else {
     // Not in a scrollable container, use viewport
+    const viewportHeight = window.innerHeight;
     effectiveSpaceBelow = viewportHeight - buttonRect.bottom;
     effectiveSpaceAbove = buttonRect.top;
-
-    // Account for footer in mobile drawer (non-scrollable case)
-    const footerBuffer = isMobileDrawer
-      ? MOBILE_FOOTER_BUFFER
-      : DESKTOP_FOOTER_BUFFER;
-    effectiveSpaceBelow -= footerBuffer;
   }
 
   // Add small buffer for visual spacing
@@ -294,18 +285,14 @@ export function MultiSelectField({
   // Calculate available space and position when dropdown opens
   // AIDEV-NOTE: Dropdown positioning logic - opens upward when insufficient space below
   // Handles both viewport boundaries and scrollable container boundaries
-  // The isMobileDrawer variable is needed because mobile drawers have different footer
-  // buffer requirements (100px vs 20px) to account for sticky footer elements that
-  // behave differently on mobile vs desktop layouts
   const calculateDropdownPositionAndHeight = () => {
     if (!buttonRef.current) return;
 
     const buttonRect = buttonRef.current.getBoundingClientRect();
-    const isMobileDrawer = window.innerWidth < TABLET_LANDSCAPE_BREAKPOINT;
     const scrollableContainer = findScrollableContainer(buttonRef.current);
 
     const { effectiveSpaceAbove, effectiveSpaceBelow } =
-      calculateAvailableSpace(buttonRect, scrollableContainer, isMobileDrawer);
+      calculateAvailableSpace(buttonRect, scrollableContainer);
 
     const { height, position } = determineDropdownLayout(
       effectiveSpaceAbove,

--- a/src/components/MultiSelectField.tsx
+++ b/src/components/MultiSelectField.tsx
@@ -14,9 +14,8 @@ const MAX_DROPDOWN_HEIGHT = 300;
 const MIN_FALLBACK_HEIGHT = 80;
 const SCROLL_DELAY_MS = 50;
 
-// CSS selectors and breakpoints
+// CSS selectors
 const STICKY_FOOTER_SELECTOR = ".z-filter-footer";
-const TABLET_LANDSCAPE_BREAKPOINT = 1024; // Matches Tailwind's tablet-landscape breakpoint
 
 // Helper to find the nearest scrollable container
 const findScrollableContainer = (
@@ -170,12 +169,8 @@ export function MultiSelectField({
       buttonRef.current.focus();
     }
 
-    // On desktop, scroll to keep control in view if removing items might cause layout shift
-    if (
-      globalThis.window !== undefined &&
-      window.innerWidth >= TABLET_LANDSCAPE_BREAKPOINT &&
-      buttonRef.current
-    ) {
+    // Scroll to keep control in view if removing items might cause layout shift
+    if (buttonRef.current) {
       const timeoutId = setTimeout(() => {
         buttonRef.current?.scrollIntoView({
           behavior: "smooth",
@@ -192,12 +187,8 @@ export function MultiSelectField({
     onChange([]);
     buttonRef.current?.focus();
 
-    // On desktop, scroll to keep control in view after clearing
-    if (
-      globalThis.window !== undefined &&
-      window.innerWidth >= TABLET_LANDSCAPE_BREAKPOINT &&
-      buttonRef.current
-    ) {
+    // Scroll to keep control in view after clearing
+    if (buttonRef.current) {
       const timeoutId = setTimeout(() => {
         buttonRef.current?.scrollIntoView({
           behavior: "smooth",

--- a/src/components/MultiSelectField.tsx
+++ b/src/components/MultiSelectField.tsx
@@ -16,6 +16,10 @@ const DESKTOP_FOOTER_BUFFER = 20;
 const MIN_FALLBACK_HEIGHT = 80;
 const SCROLL_DELAY_MS = 50;
 
+// CSS selectors and breakpoints
+const STICKY_FOOTER_SELECTOR = ".z-filter-footer";
+const TABLET_LANDSCAPE_BREAKPOINT = 1024; // Matches Tailwind's tablet-landscape breakpoint
+
 // Helper to find the nearest scrollable container
 const findScrollableContainer = (
   element: HTMLElement | null,
@@ -52,7 +56,9 @@ const calculateAvailableSpace = (
     effectiveSpaceAbove = buttonRect.top - containerRect.top;
 
     // Check for sticky footer within container
-    const stickyFooter = scrollableContainer.querySelector(".z-filter-footer");
+    const stickyFooter = scrollableContainer.querySelector(
+      STICKY_FOOTER_SELECTOR,
+    );
     if (stickyFooter) {
       const footerRect = stickyFooter.getBoundingClientRect();
       // If footer is visible, subtract its height from space below
@@ -176,7 +182,7 @@ export function MultiSelectField({
     // On desktop, scroll to keep control in view if removing items might cause layout shift
     if (
       globalThis.window !== undefined &&
-      window.innerWidth >= 1024 &&
+      window.innerWidth >= TABLET_LANDSCAPE_BREAKPOINT &&
       buttonRef.current
     ) {
       const timeoutId = setTimeout(() => {
@@ -198,7 +204,7 @@ export function MultiSelectField({
     // On desktop, scroll to keep control in view after clearing
     if (
       globalThis.window !== undefined &&
-      window.innerWidth >= 1024 &&
+      window.innerWidth >= TABLET_LANDSCAPE_BREAKPOINT &&
       buttonRef.current
     ) {
       const timeoutId = setTimeout(() => {
@@ -288,11 +294,14 @@ export function MultiSelectField({
   // Calculate available space and position when dropdown opens
   // AIDEV-NOTE: Dropdown positioning logic - opens upward when insufficient space below
   // Handles both viewport boundaries and scrollable container boundaries
+  // The isMobileDrawer variable is needed because mobile drawers have different footer
+  // buffer requirements (100px vs 20px) to account for sticky footer elements that
+  // behave differently on mobile vs desktop layouts
   const calculateDropdownPositionAndHeight = () => {
     if (!buttonRef.current) return;
 
     const buttonRect = buttonRef.current.getBoundingClientRect();
-    const isMobileDrawer = window.innerWidth < 1024;
+    const isMobileDrawer = window.innerWidth < TABLET_LANDSCAPE_BREAKPOINT;
     const scrollableContainer = findScrollableContainer(buttonRef.current);
 
     const { effectiveSpaceAbove, effectiveSpaceBelow } =


### PR DESCRIPTION
## Summary
- Fixed MultiSelect dropdown positioning to open upward when there's insufficient space below
- Detects and accounts for scrollable containers (like filter drawers)
- Handles sticky footer elements properly

## Problem
On Cast & Crew member pages and Reviews pages, when opening the filter drawer and clicking the MultiSelect field (Genres), the dropdown would:
1. Open downward beneath the sticky footer
2. Cause a scrollbar to appear
3. Have list items hidden behind the footer even when scrolling

## Solution
The dropdown now:
- Detects available space both above and below the button
- Checks if it's inside a scrollable container vs viewport
- Accounts for sticky footer elements
- Opens upward when there's more space above than below
- Recalculates position on scroll and resize events

## Test plan
- [x] Tested on Cast & Crew member page - dropdown opens correctly
- [x] Tested on Reviews page filter drawer - dropdown opens upward when near bottom
- [x] All tests pass (`npm test`)
- [x] Linting passes (`npm run lint`)
- [x] Formatting passes (`npm run format`)
- [x] TypeScript check passes (`npm run check`)
- [x] No unused dependencies (`npm run knip`)
- [x] Spelling check passes (`npm run lint:spelling`)

🤖 Generated with [Claude Code](https://claude.ai/code)