### PR TITLE
feat: use discriminated unions for pagination state

### DIFF
--- a/src/components/ListWithFilters.reducerUtils.ts
+++ b/src/components/ListWithFilters.reducerUtils.ts
@@ -48,15 +48,6 @@ export type ListWithFiltersActionType<TSortValue = unknown> =
   | SortAction<TSortValue>;
 
 /**
- * State for lists with pagination ("Show More") enabled
- * The presence of showCount acts as the discriminator
- */
-type ListWithFiltersAndShowCountState<TItem, TSortValue> =
-  BaseListWithFiltersState<TItem, TSortValue> & {
-    showCount: number; // Required for paginated lists
-  };
-
-/**
  * Union type for all list states - backwards compatible
  */
 export type ListWithFiltersState<TItem, TSortValue> =
@@ -95,6 +86,15 @@ type BaseListWithFiltersState<TItem, TSortValue> = {
 type ClearPendingFiltersAction = {
   type: ListWithFiltersActions.CLEAR_PENDING_FILTERS;
 };
+
+/**
+ * State for lists with pagination ("Show More") enabled
+ * The presence of showCount acts as the discriminator
+ */
+type ListWithFiltersAndShowCountState<TItem, TSortValue> =
+  BaseListWithFiltersState<TItem, TSortValue> & {
+    showCount: number; // Required for paginated lists
+  };
 
 /**
  * State for lists without pagination

--- a/src/components/MultiSelectField.tsx
+++ b/src/components/MultiSelectField.tsx
@@ -543,9 +543,7 @@ export function MultiSelectField({
               ${
                 dropdownPosition === "above"
                   ? "bottom-full mb-1"
-                  : `
-                top-full mt-1
-              `
+                  : `top-full mt-1`
               }
             `}
             onKeyDown={handleListboxKeyDown}

--- a/src/components/MultiSelectField.tsx
+++ b/src/components/MultiSelectField.tsx
@@ -18,6 +18,7 @@ export function MultiSelectField({
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [dropdownMaxHeight, setDropdownMaxHeight] = useState("15rem");
+  const [dropdownPosition, setDropdownPosition] = useState<"below" | "above">("below");
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -177,25 +178,81 @@ export function MultiSelectField({
     }
   };
 
-  // Calculate available space when dropdown opens
-  const calculateDropdownHeight = () => {
+  // Calculate available space and position when dropdown opens
+  // AIDEV-NOTE: Dropdown positioning logic - opens upward when insufficient space below
+  // Handles both viewport boundaries and scrollable container boundaries
+  const calculateDropdownPositionAndHeight = () => {
+    if (!buttonRef.current) return;
+
+    const buttonRect = buttonRef.current.getBoundingClientRect();
+    const viewportHeight = window.innerHeight;
     const isMobileDrawer = window.innerWidth < 1024;
-
-    if (isMobileDrawer && buttonRef.current) {
-      const buttonRect = buttonRef.current.getBoundingClientRect();
-      const viewportHeight = window.innerHeight;
-      const footerHeight = 100;
-      const availableSpace = viewportHeight - buttonRect.bottom - footerHeight;
-      const minHeight = 120;
-      const maxHeight = 300;
-
-      if (availableSpace < minHeight) {
-        setDropdownMaxHeight(`${Math.max(availableSpace, 80)}px`);
-      } else {
-        setDropdownMaxHeight(`${Math.min(availableSpace, maxHeight)}px`);
+    
+    // Find the nearest scrollable container (if any)
+    let scrollableContainer: HTMLElement | null = null;
+    let element = buttonRef.current.parentElement;
+    
+    while (element && element !== document.body) {
+      const style = window.getComputedStyle(element);
+      const overflowY = style.overflowY;
+      
+      if (overflowY === 'auto' || overflowY === 'scroll') {
+        scrollableContainer = element;
+        break;
+      }
+      element = element.parentElement;
+    }
+    
+    // Calculate boundaries based on container or viewport
+    let effectiveSpaceBelow: number;
+    let effectiveSpaceAbove: number;
+    
+    if (scrollableContainer) {
+      // We're inside a scrollable container
+      const containerRect = scrollableContainer.getBoundingClientRect();
+      
+      // Space within the visible container area
+      effectiveSpaceBelow = containerRect.bottom - buttonRect.bottom;
+      effectiveSpaceAbove = buttonRect.top - containerRect.top;
+      
+      // Check for sticky footer within container
+      const stickyFooter = scrollableContainer.querySelector('.z-filter-footer');
+      if (stickyFooter) {
+        const footerRect = stickyFooter.getBoundingClientRect();
+        // If footer is visible, subtract its height from space below
+        if (footerRect.top < containerRect.bottom) {
+          effectiveSpaceBelow = Math.min(effectiveSpaceBelow, footerRect.top - buttonRect.bottom);
+        }
       }
     } else {
-      setDropdownMaxHeight("15rem");
+      // Not in a scrollable container, use viewport
+      effectiveSpaceBelow = viewportHeight - buttonRect.bottom;
+      effectiveSpaceAbove = buttonRect.top;
+      
+      // Account for footer in mobile drawer (non-scrollable case)
+      const footerBuffer = isMobileDrawer ? 100 : 20;
+      effectiveSpaceBelow -= footerBuffer;
+    }
+    
+    // Add small buffer for visual spacing
+    effectiveSpaceAbove -= 20;
+    effectiveSpaceBelow -= 10;
+    
+    // Minimum height needed for a usable dropdown
+    const minDropdownHeight = 120;
+    const maxDropdownHeight = 300;
+    
+    // Determine position based on available space
+    if (effectiveSpaceBelow < minDropdownHeight && effectiveSpaceAbove > effectiveSpaceBelow) {
+      // Open upward if more space above
+      setDropdownPosition("above");
+      const height = Math.min(Math.max(effectiveSpaceAbove, 80), maxDropdownHeight);
+      setDropdownMaxHeight(`${height}px`);
+    } else {
+      // Default to opening below
+      setDropdownPosition("below");
+      const height = Math.min(Math.max(effectiveSpaceBelow, 80), maxDropdownHeight);
+      setDropdownMaxHeight(`${height}px`);
     }
   };
 
@@ -246,24 +303,52 @@ export function MultiSelectField({
     };
   }, [isOpen]);
 
-  // Calculate dropdown height when it opens
+  // Calculate dropdown position and height when it opens
   useEffect(() => {
     if (isOpen) {
-      calculateDropdownHeight();
+      calculateDropdownPositionAndHeight();
     }
   }, [isOpen]);
 
-  // Add resize listener
+  // Add resize and scroll listeners
   useEffect(() => {
+    if (!isOpen) return;
+
     const handleResize = () => {
-      if (isOpen) {
-        calculateDropdownHeight();
-      }
+      calculateDropdownPositionAndHeight();
+    };
+
+    const handleScroll = () => {
+      calculateDropdownPositionAndHeight();
     };
 
     if (globalThis.window !== undefined) {
       window.addEventListener("resize", handleResize);
-      return () => window.removeEventListener("resize", handleResize);
+      
+      // Find and listen to scrollable container
+      let scrollableContainer: HTMLElement | null = null;
+      if (buttonRef.current) {
+        let element = buttonRef.current.parentElement;
+        while (element && element !== document.body) {
+          const style = window.getComputedStyle(element);
+          if (style.overflowY === 'auto' || style.overflowY === 'scroll') {
+            scrollableContainer = element;
+            break;
+          }
+          element = element.parentElement;
+        }
+      }
+      
+      if (scrollableContainer) {
+        scrollableContainer.addEventListener("scroll", handleScroll);
+      }
+      
+      return () => {
+        window.removeEventListener("resize", handleResize);
+        if (scrollableContainer) {
+          scrollableContainer.removeEventListener("scroll", handleScroll);
+        }
+      };
     }
   }, [isOpen]);
 
@@ -436,10 +521,11 @@ export function MultiSelectField({
         {isOpen && (
           <div
             className={`
-              absolute z-10 mt-1 w-full overflow-auto rounded-sm bg-default py-1
+              absolute z-10 w-full overflow-auto rounded-sm bg-default py-1
               text-base text-subtle
               shadow-[0px_0px_0px_1px_rgba(0,0,0,0.1),0px_4px_11px_rgba(0,0,0,0.1)]
               focus:outline-none
+              ${dropdownPosition === "above" ? "bottom-full mb-1" : "top-full mt-1"}
             `}
             onKeyDown={handleListboxKeyDown}
             ref={dropdownRef}

--- a/src/components/MultiSelectField.tsx
+++ b/src/components/MultiSelectField.tsx
@@ -18,7 +18,9 @@ export function MultiSelectField({
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [dropdownMaxHeight, setDropdownMaxHeight] = useState("15rem");
-  const [dropdownPosition, setDropdownPosition] = useState<"below" | "above">("below");
+  const [dropdownPosition, setDropdownPosition] = useState<"above" | "below">(
+    "below",
+  );
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -187,71 +189,84 @@ export function MultiSelectField({
     const buttonRect = buttonRef.current.getBoundingClientRect();
     const viewportHeight = window.innerHeight;
     const isMobileDrawer = window.innerWidth < 1024;
-    
+
     // Find the nearest scrollable container (if any)
-    let scrollableContainer: HTMLElement | null = null;
+    let scrollableContainer: HTMLElement | undefined;
     let element = buttonRef.current.parentElement;
-    
+
     while (element && element !== document.body) {
-      const style = window.getComputedStyle(element);
+      const style = globalThis.getComputedStyle(element);
       const overflowY = style.overflowY;
-      
-      if (overflowY === 'auto' || overflowY === 'scroll') {
+
+      if (overflowY === "auto" || overflowY === "scroll") {
         scrollableContainer = element;
         break;
       }
       element = element.parentElement;
     }
-    
+
     // Calculate boundaries based on container or viewport
     let effectiveSpaceBelow: number;
     let effectiveSpaceAbove: number;
-    
+
     if (scrollableContainer) {
       // We're inside a scrollable container
       const containerRect = scrollableContainer.getBoundingClientRect();
-      
+
       // Space within the visible container area
       effectiveSpaceBelow = containerRect.bottom - buttonRect.bottom;
       effectiveSpaceAbove = buttonRect.top - containerRect.top;
-      
+
       // Check for sticky footer within container
-      const stickyFooter = scrollableContainer.querySelector('.z-filter-footer');
+      const stickyFooter =
+        scrollableContainer.querySelector(".z-filter-footer");
       if (stickyFooter) {
         const footerRect = stickyFooter.getBoundingClientRect();
         // If footer is visible, subtract its height from space below
         if (footerRect.top < containerRect.bottom) {
-          effectiveSpaceBelow = Math.min(effectiveSpaceBelow, footerRect.top - buttonRect.bottom);
+          effectiveSpaceBelow = Math.min(
+            effectiveSpaceBelow,
+            footerRect.top - buttonRect.bottom,
+          );
         }
       }
     } else {
       // Not in a scrollable container, use viewport
       effectiveSpaceBelow = viewportHeight - buttonRect.bottom;
       effectiveSpaceAbove = buttonRect.top;
-      
+
       // Account for footer in mobile drawer (non-scrollable case)
       const footerBuffer = isMobileDrawer ? 100 : 20;
       effectiveSpaceBelow -= footerBuffer;
     }
-    
+
     // Add small buffer for visual spacing
     effectiveSpaceAbove -= 20;
     effectiveSpaceBelow -= 10;
-    
+
     // Minimum height needed for a usable dropdown
     const minDropdownHeight = 120;
     const maxDropdownHeight = 300;
-    
+
     // Determine position based on available space
-    if (effectiveSpaceBelow < minDropdownHeight && effectiveSpaceAbove > effectiveSpaceBelow) {
+    if (
+      effectiveSpaceBelow < minDropdownHeight &&
+      effectiveSpaceAbove > effectiveSpaceBelow
+    ) {
       // Open upward if more space above
       setDropdownPosition("above");
-      const height = Math.min(Math.max(effectiveSpaceAbove, 80), maxDropdownHeight);
+      const height = Math.min(
+        Math.max(effectiveSpaceAbove, 80),
+        maxDropdownHeight,
+      );
       setDropdownMaxHeight(`${height}px`);
     } else {
       // Default to opening below
       setDropdownPosition("below");
-      const height = Math.min(Math.max(effectiveSpaceBelow, 80), maxDropdownHeight);
+      const height = Math.min(
+        Math.max(effectiveSpaceBelow, 80),
+        maxDropdownHeight,
+      );
       setDropdownMaxHeight(`${height}px`);
     }
   };
@@ -324,25 +339,25 @@ export function MultiSelectField({
 
     if (globalThis.window !== undefined) {
       window.addEventListener("resize", handleResize);
-      
+
       // Find and listen to scrollable container
-      let scrollableContainer: HTMLElement | null = null;
+      let scrollableContainer: HTMLElement | undefined;
       if (buttonRef.current) {
         let element = buttonRef.current.parentElement;
         while (element && element !== document.body) {
-          const style = window.getComputedStyle(element);
-          if (style.overflowY === 'auto' || style.overflowY === 'scroll') {
+          const style = globalThis.getComputedStyle(element);
+          if (style.overflowY === "auto" || style.overflowY === "scroll") {
             scrollableContainer = element;
             break;
           }
           element = element.parentElement;
         }
       }
-      
+
       if (scrollableContainer) {
         scrollableContainer.addEventListener("scroll", handleScroll);
       }
-      
+
       return () => {
         window.removeEventListener("resize", handleResize);
         if (scrollableContainer) {
@@ -525,7 +540,13 @@ export function MultiSelectField({
               text-base text-subtle
               shadow-[0px_0px_0px_1px_rgba(0,0,0,0.1),0px_4px_11px_rgba(0,0,0,0.1)]
               focus:outline-none
-              ${dropdownPosition === "above" ? "bottom-full mb-1" : "top-full mt-1"}
+              ${
+                dropdownPosition === "above"
+                  ? "bottom-full mb-1"
+                  : `
+                top-full mt-1
+              `
+              }
             `}
             onKeyDown={handleListboxKeyDown}
             ref={dropdownRef}


### PR DESCRIPTION
## Summary
- Replace runtime error check with compile-time type safety using discriminated unions
- The presence of `showCount` (number vs undefined) acts as the discriminator
- TypeScript now prevents calling `showMore` on non-paginated states at compile time

## Changes
- Remove runtime error throw in `showMore` function
- Add `ListWithFiltersAndShowCountState` type for paginated lists  
- Use `showCount` presence as natural discriminator
- Simplify `createInitialState` to single return statement

## Context
Based on PR #2355 review feedback about catching runtime errors at compile time with better type constraints.

## Test plan
- [x] All tests pass (`npm test`)
- [x] TypeScript checks pass (`npm run check`)
- [x] Linting passes (`npm run lint`)
- [x] Formatting passes (`npm run format`)
- [x] No unused exports (`npm run knip`)

🤖 Generated with [Claude Code](https://claude.ai/code)