### PR TITLE
feat: consolidate OpenGraphImage utilities and improve type safety

### DIFF
--- a/src/components/Home/OpenGraphImage.tsx
+++ b/src/components/Home/OpenGraphImage.tsx
@@ -1,9 +1,16 @@
 import type { JSX } from "react";
+
+export type HomeOpenGraphImageComponentType = (
+  props: HomeOpenGraphImageProps,
+) => JSX.Element;
+
+type HomeOpenGraphImageProps = {
+  backdrop: string;
+};
+
 export function OpenGraphImage({
   backdrop,
-}: {
-  backdrop: string;
-}): JSX.Element {
+}: HomeOpenGraphImageProps): JSX.Element {
   return (
     <div
       style={{

--- a/src/components/OpenGraphImage.tsx
+++ b/src/components/OpenGraphImage.tsx
@@ -1,13 +1,20 @@
 import type { JSX } from "react";
+
+export type OpenGraphImageComponentType = (
+  props: OpenGraphImageProps,
+) => JSX.Element;
+
+type OpenGraphImageProps = {
+  backdrop: string;
+  sectionHead?: string;
+  title: string;
+};
+
 export function OpenGraphImage({
   backdrop,
   sectionHead = "Frank's Movie Log",
   title,
-}: {
-  backdrop: string;
-  sectionHead?: string;
-  title: string;
-}): JSX.Element {
+}: OpenGraphImageProps): JSX.Element {
   return (
     <div
       style={{

--- a/src/components/Review/OpenGraphImage.tsx
+++ b/src/components/Review/OpenGraphImage.tsx
@@ -1,15 +1,22 @@
 import type { JSX } from "react";
+
+export type ReviewOpenGraphImageComponentType = (
+  props: ReviewOpenGraphImageProps,
+) => JSX.Element;
+
+type ReviewOpenGraphImageProps = {
+  backdrop: string;
+  grade: string;
+  releaseYear: string;
+  title: string;
+};
+
 export function OpenGraphImage({
   backdrop,
   grade,
   releaseYear,
   title,
-}: {
-  backdrop: string;
-  grade: string;
-  releaseYear: string;
-  title: string;
-}): JSX.Element {
+}: ReviewOpenGraphImageProps): JSX.Element {
   return (
     <div
       style={{


### PR DESCRIPTION
## Summary

- Consolidated the `componentToImage` utility back into a shared utils file to eliminate code duplication across three OpenGraphImage components
- Each OpenGraphImage component now exports its own properly typed function type for better type safety
- Simplified the implementation by removing defensive code for cases that never occur in practice

## Changes

- **Extracted shared logic**: Moved `componentToImage` and related functions back to `src/utils/componentToImage.ts`
- **Improved type definitions**: Each component exports its own type (`HomeOpenGraphImageComponentType`, `OpenGraphImageComponentType`, `ReviewOpenGraphImageComponentType`)
- **Simplified serializeJsx**: Removed branches for cases we never hit since we know exactly what JSX the OpenGraphImage components produce
- **Updated imports**: All og.jpg.ts files now import the component and utility separately

## Test plan

- [x] All TypeScript checks pass (`npm run check`)
- [x] All ESLint checks pass (`npm run lint`)
- [x] All formatting checks pass (`npm run format`)
- [x] No unused dependencies (`npm run knip`)
- [x] Successfully rebased on latest main

🤖 Generated with [Claude Code](https://claude.ai/code)