### PR TITLE
refactor: use standard grouping pattern for Viewings component

### DIFF
--- a/src/components/ListWithFilters.reducerUtils.ts
+++ b/src/components/ListWithFilters.reducerUtils.ts
@@ -32,6 +32,11 @@ export enum ListWithFiltersActions {
   SORT = "SORT",
 }
 
+export type GroupFn<TItem, TSortValue> = (
+  items: TItem[],
+  sortValue: TSortValue,
+) => Map<string, TItem[]>;
+
 /**
  * Union type of all ListWithFilters actions
  */
@@ -151,7 +156,7 @@ type SortAction<TSortValue> = {
  */
 export function buildGroupValues<TItem, TSortValue>(
   keyFn: (item: TItem, sortValue: TSortValue) => string,
-) {
+): GroupFn<TItem, TSortValue> {
   return function groupValues(
     items: TItem[],
     sortValue: TSortValue,
@@ -188,7 +193,7 @@ export function createInitialState<TItem, TSortValue>({
   sortFn,
   values,
 }: {
-  groupFn?: (values: TItem[], sort: TSortValue) => Map<string, TItem[]>;
+  groupFn?: GroupFn<TItem, TSortValue>;
   initialSort: TSortValue;
   showMoreEnabled?: boolean;
   sortFn: (values: TItem[], sort: TSortValue) => TItem[];
@@ -271,7 +276,7 @@ export function handleListWithFiltersAction<
   state: ListWithFiltersState<TItem, TSortValue> & TExtendedState,
   action: ListWithFiltersActionType<TSortValue>,
   handlers: {
-    groupFn?: (values: TItem[], sort: TSortValue) => Map<string, TItem[]>;
+    groupFn?: GroupFn<TItem, TSortValue>;
     sortFn: (values: TItem[], sort: TSortValue) => TItem[];
   },
   extendedState?: TExtendedState,
@@ -417,7 +422,7 @@ export function handleToggleReviewedAction<
 >(
   state: ListWithFiltersState<TItem, TSortValue> & TExtendedState,
   sortFn: (values: TItem[], sort: TSortValue) => TItem[],
-  groupFn?: (values: TItem[], sort: TSortValue) => Map<string, TItem[]>,
+  groupFn?: GroupFn<TItem, TSortValue>,
 ): ListWithFiltersState<TItem, TSortValue> & TExtendedState {
   const hideReviewed = !state.hideReviewed;
 
@@ -569,7 +574,7 @@ export function updatePendingFilter<TItem, TSortValue>(
 function applyPendingFilters<TItem, TSortValue>(
   state: ListWithFiltersState<TItem, TSortValue>,
   sortFn: (values: TItem[], sort: TSortValue) => TItem[],
-  groupFn?: (values: TItem[], sort: TSortValue) => Map<string, TItem[]>,
+  groupFn?: GroupFn<TItem, TSortValue>,
 ): ListWithFiltersState<TItem, TSortValue> {
   const filteredValues = sortFn(
     filterValues({
@@ -693,7 +698,7 @@ function resetPendingFilters<TItem, TSortValue>(
 function showMore<TItem, TSortValue>(
   state: ListWithFiltersAndShowCountState<TItem, TSortValue>,
   increment: number,
-  groupFn?: (values: TItem[], sort: TSortValue) => Map<string, TItem[]>,
+  groupFn?: GroupFn<TItem, TSortValue>,
 ): ListWithFiltersAndShowCountState<TItem, TSortValue> {
   const showCount = state.showCount + increment;
   const groupedValues = groupFn
@@ -718,7 +723,7 @@ function updateSort<TItem, TSortValue>(
   state: ListWithFiltersState<TItem, TSortValue>,
   sortValue: TSortValue,
   sortFn: (values: TItem[], sort: TSortValue) => TItem[],
-  groupFn?: (values: TItem[], sort: TSortValue) => Map<string, TItem[]>,
+  groupFn?: GroupFn<TItem, TSortValue>,
 ): ListWithFiltersState<TItem, TSortValue> {
   const filteredValues = sortFn(state.filteredValues, sortValue);
   const valuesToGroup = state.showCount


### PR DESCRIPTION
## Summary
Refactors the Viewings component to use the standard `ListWithFilters.reducerUtils` grouping pattern, eliminating the need for a separate `useMemo` hook for indexing viewings by date.

## Changes
- Remove `useMemo` hook for indexing viewings by date in the component
- Create a custom grouping function `groupValuesSortedBySequence` that:
  - Groups viewings by date key (year-month-day)
  - Sorts viewings within each day by sequence
- Export `GroupFn` type from `ListWithFilters.reducerUtils` for proper typing
- Update all calendar components to use `state.groupedValues` Map instead of local index

## Benefits
- **Consistency**: Follows the established pattern used throughout the codebase
- **Maintainability**: All state transformations are now in the reducer
- **Performance**: Same O(1) lookup performance for calendar days
- **Type Safety**: Properly typed using the exported `GroupFn` type

## Test Plan
✅ All tests pass (`npm test`)
✅ ESLint passes (`npm run lint`)
✅ Spelling check passes (`npm run lint:spelling`)
✅ TypeScript check passes (`npm run check`)
✅ No unused dependencies (`npm run knip`)
✅ Formatting is correct (`npm run format`)

🤖 Generated with [Claude Code](https://claude.ai/code)