### PR TITLE
refactor: rename initialValue(s) props to defaultValue(s)

### DIFF
--- a/src/components/fields/GradeField.tsx
+++ b/src/components/fields/GradeField.tsx
@@ -48,22 +48,22 @@ const gradeOptions = [
 /**
  * Grade range selector with from/to letter grade dropdowns.
  * @param props - Component props
- * @param props.initialValues - Initial [min, max] grade values
+ * @param props.defaultValues - Default [min, max] grade values
  * @param props.label - Field label text
  * @param props.onGradeChange - Handler for grade range changes
  * @returns Grade range selector with two dropdowns
  */
 export function GradeField({
-  initialValues,
+  defaultValues,
   label,
   onGradeChange,
 }: {
-  initialValues: [number, number] | undefined;
+  defaultValues: [number, number] | undefined;
   label: string;
   onGradeChange: (values: [number, number]) => void;
 }): React.JSX.Element {
-  const [minValue, setMinValue] = useState(initialMinGradeValue(initialValues));
-  const [maxValue, setMaxValue] = useState(initialMaxGradeValue(initialValues));
+  const [minValue, setMinValue] = useState(defaultMinValue(defaultValues));
+  const [maxValue, setMaxValue] = useState(defaultMaxValue(defaultValues));
 
   const handleMinChange = (value: string): void => {
     const newMin = Number.parseInt(value, 10);
@@ -96,7 +96,7 @@ export function GradeField({
             From
           </span>
           <SelectInput
-            defaultValue={initialMinGradeValue(initialValues)}
+            defaultValue={defaultMinValue(defaultValues)}
             onChange={(e) => handleMinChange(e.target.value)}
           >
             {[...gradeOptions].reverse()}
@@ -107,7 +107,7 @@ export function GradeField({
             to
           </span>
           <SelectInput
-            defaultValue={initialMaxGradeValue(initialValues)}
+            defaultValue={defaultMaxValue(defaultValues)}
             onChange={(e) => handleMaxChange(e.target.value)}
           >
             {[...gradeOptions]}
@@ -118,10 +118,10 @@ export function GradeField({
   );
 }
 
-function initialMaxGradeValue(selectedValues?: [number, number]): number {
+function defaultMaxValue(selectedValues?: [number, number]): number {
   return selectedValues ? selectedValues[1] : 13;
 }
 
-function initialMinGradeValue(selectedValues?: [number, number]): number {
+function defaultMinValue(selectedValues?: [number, number]): number {
   return selectedValues ? selectedValues[0] : 1;
 }

--- a/src/components/fields/MultiSelectField.spec.tsx
+++ b/src/components/fields/MultiSelectField.spec.tsx
@@ -12,12 +12,12 @@ if (!Element.prototype.scrollIntoView) {
 const createDefaultProps = (
   overrides = {},
 ): {
-  initialValues: string[];
+  defaultValues: string[];
   label: string;
   onChange: (values: string[]) => void;
   options: string[];
 } => ({
-  initialValues: [],
+  defaultValues: [],
   label: "Test Label",
   onChange: vi.fn(),
   options: [
@@ -45,7 +45,7 @@ describe("MultiSelectField", () => {
 
     it("displays initial selected values", ({ expect }) => {
       const props = createDefaultProps({
-        initialValues: ["Option 1", "Option 3"],
+        defaultValues: ["Option 1", "Option 3"],
       });
       render(<MultiSelectField {...props} />);
 
@@ -1138,12 +1138,12 @@ describe("MultiSelectField", () => {
   // Edge cases for keyboard navigation have been moved to the "keyboard navigation" describe block
 
   describe("form reset behavior", () => {
-    it("resets to initial values when form is reset", async ({ expect }) => {
+    it("resets to default values when form is reset", async ({ expect }) => {
       const onChange = vi.fn();
       const user = userEvent.setup();
 
       const props = createDefaultProps({
-        initialValues: ["Option 1", "Option 2"],
+        defaultValues: ["Option 1", "Option 2"],
         onChange,
       });
       const { container } = render(
@@ -1175,7 +1175,7 @@ describe("MultiSelectField", () => {
         form?.reset();
       });
 
-      // Should reset to initial values
+      // Should reset to default values
       await waitFor(() => {
         expect(screen.getByText("Option 1")).toBeInTheDocument();
         expect(screen.getByText("Option 2")).toBeInTheDocument();
@@ -1183,7 +1183,7 @@ describe("MultiSelectField", () => {
       });
     });
 
-    it("clears all selections when form is reset with no initial values", async ({
+    it("clears all selections when form is reset with no default values", async ({
       expect,
     }) => {
       const onChange = vi.fn();

--- a/src/components/fields/MultiSelectField.tsx
+++ b/src/components/fields/MultiSelectField.tsx
@@ -123,25 +123,25 @@ const determineDropdownLayout = (
 /**
  * Multi-select dropdown field with keyboard navigation.
  * @param props - Component props
- * @param props.initialValues - Initially selected values
+ * @param props.defaultValues - Default selected values
  * @param props.label - Field label text
  * @param props.onChange - Handler for selection changes
  * @param props.options - Available options to select from
  * @returns Multi-select field with dropdown and selected items
  */
 export function MultiSelectField({
-  initialValues,
+  defaultValues,
   label,
   onChange,
   options,
 }: {
-  initialValues: readonly string[] | undefined;
+  defaultValues: readonly string[] | undefined;
   label: string;
   onChange: (values: string[]) => void;
   options: readonly string[];
 }): React.JSX.Element {
   const [selectedOptions, setSelectedOptions] = useState<string[]>(
-    initialValues ? [...initialValues] : [],
+    defaultValues ? [...defaultValues] : [],
   );
   const [isOpen, setIsOpen] = useState(false);
   const [dropdownMaxHeight, setDropdownMaxHeight] = useState("15rem");
@@ -435,7 +435,7 @@ export function MultiSelectField({
 
     const handleFormReset = (): void => {
       // Reset to initial values when form is reset
-      setSelectedOptions(initialValues ? [...initialValues] : []);
+      setSelectedOptions(defaultValues ? [...defaultValues] : []);
       setIsOpen(false);
       setHighlightedIndex(-1);
     };
@@ -445,7 +445,7 @@ export function MultiSelectField({
     return (): void => {
       form.removeEventListener("reset", handleFormReset);
     };
-  }, [initialValues]);
+  }, [defaultValues]);
 
   // Cleanup timeouts on unmount
   useEffect(() => {

--- a/src/components/fields/TextField.tsx
+++ b/src/components/fields/TextField.tsx
@@ -12,19 +12,19 @@ type onChangeHandler = (value: string) => void;
 /**
  * Text input field with label and debounced change handler.
  * @param props - Component props
- * @param props.initialValue - Initial input value
+ * @param props.defaultValue - Default input value
  * @param props.label - Field label text
  * @param props.onInputChange - Debounced handler for input changes
  * @param props.placeholder - Placeholder text
  * @returns Labeled text input field
  */
 export function TextField({
-  initialValue,
+  defaultValue,
   label,
   onInputChange,
   placeholder,
 }: {
-  initialValue: string | undefined;
+  defaultValue: string | undefined;
   label: string;
   onInputChange: onChangeHandler;
   placeholder: string;
@@ -48,7 +48,7 @@ export function TextField({
           outline-accent
           placeholder:text-default placeholder:opacity-50
         `}
-        defaultValue={initialValue}
+        defaultValue={defaultValue}
         onChange={handleChange}
         placeholder={placeholder}
         type="text"

--- a/src/components/fields/YearField.tsx
+++ b/src/components/fields/YearField.tsx
@@ -6,25 +6,25 @@ import { SelectInput } from "./SelectInput";
 /**
  * Year range selector with from/to dropdowns.
  * @param props - Component props
- * @param props.initialValues - Initial [min, max] year values
+ * @param props.defaultValues - Default [min, max] year values
  * @param props.label - Field label text
  * @param props.onYearChange - Handler for year range changes
  * @param props.years - Available years to select from
  * @returns Year range selector with two dropdowns
  */
 export function YearField({
-  initialValues,
+  defaultValues,
   label,
   onYearChange,
   years,
 }: {
-  initialValues: [string, string] | undefined;
+  defaultValues: [string, string] | undefined;
   label: string;
   onYearChange: (values: [string, string]) => void;
   years: readonly string[];
 }): React.JSX.Element {
-  const [minYear, setMinYear] = useState(initialMinYear(years, initialValues));
-  const [maxYear, setMaxYear] = useState(initialMaxYear(years, initialValues));
+  const [minYear, setMinYear] = useState(defaultMinYear(years, defaultValues));
+  const [maxYear, setMaxYear] = useState(defaultMaxYear(years, defaultValues));
 
   const handleMinChange = (value: string): void => {
     const newMin = value;
@@ -57,7 +57,7 @@ export function YearField({
             From
           </span>
           <SelectInput
-            defaultValue={initialMinYear(years, initialValues)}
+            defaultValue={defaultMinYear(years, defaultValues)}
             onChange={(e) => handleMinChange(e.target.value)}
           >
             {years.map((year) => {
@@ -74,7 +74,7 @@ export function YearField({
             to
           </span>
           <SelectInput
-            defaultValue={initialMaxYear(years, initialValues)}
+            defaultValue={defaultMaxYear(years, defaultValues)}
             onChange={(e) => handleMaxChange(e.target.value)}
           >
             {[...years].reverse().map((year) => {
@@ -91,14 +91,14 @@ export function YearField({
   );
 }
 
-function initialMaxYear(
+function defaultMaxYear(
   allValues: readonly string[],
   selectedValues?: [string, string],
 ): string {
   return selectedValues ? selectedValues[1] : (allValues.at(-1) as string);
 }
 
-function initialMinYear(
+function defaultMinYear(
   allValues: readonly string[],
   selectedValues?: [string, string],
 ): string {

--- a/src/components/fields/YearField.tsx
+++ b/src/components/fields/YearField.tsx
@@ -23,8 +23,8 @@ export function YearField({
   onYearChange: (values: [string, string]) => void;
   years: readonly string[];
 }): React.JSX.Element {
-  const [minYear, setMinYear] = useState(defaultMinYear(years, defaultValues));
-  const [maxYear, setMaxYear] = useState(defaultMaxYear(years, defaultValues));
+  const [minYear, setMinYear] = useState(defaultMinValue(years, defaultValues));
+  const [maxYear, setMaxYear] = useState(defaultMaxValue(years, defaultValues));
 
   const handleMinChange = (value: string): void => {
     const newMin = value;
@@ -57,7 +57,7 @@ export function YearField({
             From
           </span>
           <SelectInput
-            defaultValue={defaultMinYear(years, defaultValues)}
+            defaultValue={defaultMinValue(years, defaultValues)}
             onChange={(e) => handleMinChange(e.target.value)}
           >
             {years.map((year) => {
@@ -74,7 +74,7 @@ export function YearField({
             to
           </span>
           <SelectInput
-            defaultValue={defaultMaxYear(years, defaultValues)}
+            defaultValue={defaultMaxValue(years, defaultValues)}
             onChange={(e) => handleMaxChange(e.target.value)}
           >
             {[...years].reverse().map((year) => {
@@ -91,14 +91,14 @@ export function YearField({
   );
 }
 
-function defaultMaxYear(
+function defaultMaxValue(
   allValues: readonly string[],
   selectedValues?: [string, string],
 ): string {
   return selectedValues ? selectedValues[1] : (allValues.at(-1) as string);
 }
 
-function defaultMinYear(
+function defaultMinValue(
   allValues: readonly string[],
   selectedValues?: [string, string],
 ): string {

--- a/src/components/filter-and-sort/CollectionFilters.tsx
+++ b/src/components/filter-and-sort/CollectionFilters.tsx
@@ -12,14 +12,14 @@ export function CollectionFilters({
   name,
 }: {
   name: {
-    initialValue: CollectionFiltersValues["name"];
+    defaultValue: CollectionFiltersValues["name"];
     onChange: (value: string) => void;
   };
 }): React.JSX.Element {
   return (
     <>
       <TextField
-        initialValue={name.initialValue}
+        defaultValue={name.defaultValue}
         label="Name"
         onInputChange={name.onChange}
         placeholder="Enter all or part of a name"

--- a/src/components/filter-and-sort/MaybeReviewedTitleFilters.tsx
+++ b/src/components/filter-and-sort/MaybeReviewedTitleFilters.tsx
@@ -5,7 +5,7 @@ import { ReviewedTitleFilters } from "./ReviewedTitleFilters";
 
 type Props = ComponentProps<typeof ReviewedTitleFilters> & {
   reviewedStatus: {
-    initialValue?: string;
+    defaultValue?: string;
     onChange: (value: string) => void;
   };
 };
@@ -33,7 +33,7 @@ export function MaybeReviewedTitleFilters({
         title={title}
       />
       <ReviewedStatusFilter
-        defaultValue={reviewedStatus.initialValue}
+        defaultValue={reviewedStatus.defaultValue}
         onChange={reviewedStatus.onChange}
       />
     </>

--- a/src/components/filter-and-sort/ReviewedTitleFilters.tsx
+++ b/src/components/filter-and-sort/ReviewedTitleFilters.tsx
@@ -7,11 +7,11 @@ import { TitleFilters } from "./TitleFilters";
 
 type Props = ComponentProps<typeof TitleFilters> & {
   grade: {
-    initialValue?: [number, number];
+    defaultValues?: [number, number];
     onChange: (values: [number, number]) => void;
   };
   reviewYear: {
-    initialValue?: [string, string];
+    defaultValues?: [string, string];
     onChange: (values: [string, string]) => void;
     values: readonly string[];
   };
@@ -33,12 +33,12 @@ export function ReviewedTitleFilters({
     <>
       <TitleFilters genres={genres} releaseYear={releaseYear} title={title} />
       <GradeField
-        initialValues={grade.initialValue}
+        defaultValues={grade.defaultValues}
         label="Grade"
         onGradeChange={grade.onChange}
       />
       <YearField
-        initialValues={reviewYear.initialValue}
+        defaultValues={reviewYear.defaultValues}
         label="Review Year"
         onYearChange={reviewYear.onChange}
         years={reviewYear.values}

--- a/src/components/filter-and-sort/TitleFilters.tsx
+++ b/src/components/filter-and-sort/TitleFilters.tsx
@@ -4,17 +4,17 @@ import { YearField } from "~/components/fields/YearField";
 
 type TitleFiltersProps = {
   genres?: {
-    initialValue?: readonly string[];
+    defaultValues?: readonly string[];
     onChange: (values: string[]) => void;
     values: readonly string[];
   };
   releaseYear: {
-    initialValue?: [string, string];
+    defaultValues?: [string, string];
     onChange: (values: [string, string]) => void;
     values: readonly string[];
   };
   title: {
-    initialValue?: string;
+    defaultValue?: string;
     onChange: (value: string) => void;
   };
 };
@@ -35,20 +35,20 @@ export function TitleFilters({
   return (
     <>
       <TextField
-        initialValue={title.initialValue}
+        defaultValue={title.defaultValue}
         label="Title"
         onInputChange={title.onChange}
         placeholder="Enter all or part of a title"
       />
       <YearField
-        initialValues={releaseYear.initialValue}
+        defaultValues={releaseYear.defaultValues}
         label="Release Year"
         onYearChange={releaseYear.onChange}
         years={releaseYear.values}
       />
       {genres && (
         <MultiSelectField
-          initialValues={genres.initialValue}
+          defaultValues={genres.defaultValues}
           label="Genres"
           onChange={genres.onChange}
           options={genres.values}

--- a/src/features/cast-and-crew-member-titles/Filters.tsx
+++ b/src/features/cast-and-crew-member-titles/Filters.tsx
@@ -55,36 +55,36 @@ export function Filters({
       )}
       <MaybeReviewedTitleFilters
         genres={{
-          initialValue: filterValues.genres,
+          defaultValues: filterValues.genres,
 
           onChange: (values) =>
             dispatch(createGenresFilterChangedAction(values)),
           values: distinctGenres,
         }}
         grade={{
-          initialValue: filterValues.gradeValue,
+          defaultValues: filterValues.gradeValue,
           onChange: (values) =>
             dispatch(createGradeFilterChangedAction(values)),
         }}
         releaseYear={{
-          initialValue: filterValues.releaseYear,
+          defaultValues: filterValues.releaseYear,
           onChange: (values) =>
             dispatch(createReleaseYearFilterChangedAction(values)),
           values: distinctReleaseYears,
         }}
         reviewedStatus={{
-          initialValue: filterValues.reviewedStatus,
+          defaultValue: filterValues.reviewedStatus,
           onChange: (value) =>
             dispatch(createReviewedStatusFilterChangedAction(value)),
         }}
         reviewYear={{
-          initialValue: filterValues.reviewYear,
+          defaultValues: filterValues.reviewYear,
           onChange: (values) =>
             dispatch(createReviewYearFilterChangedAction(values)),
           values: distinctReviewYears,
         }}
         title={{
-          initialValue: filterValues.title,
+          defaultValue: filterValues.title,
           onChange: (value) => dispatch(createTitleFilterChangedAction(value)),
         }}
       />

--- a/src/features/cast-and-crew/Filters.tsx
+++ b/src/features/cast-and-crew/Filters.tsx
@@ -29,7 +29,7 @@ export function Filters({
     <>
       <CollectionFilters
         name={{
-          initialValue: filterValues.name,
+          defaultValue: filterValues.name,
           onChange: (value) => dispatch(createNameFilterChangedAction(value)),
         }}
       />

--- a/src/features/collection-titles/Filters.tsx
+++ b/src/features/collection-titles/Filters.tsx
@@ -40,34 +40,34 @@ export function Filters({
   return (
     <MaybeReviewedTitleFilters
       genres={{
-        initialValue: filterValues.genres,
+        defaultValues: filterValues.genres,
 
         onChange: (values) => dispatch(createGenresFilterChangedAction(values)),
         values: distinctGenres,
       }}
       grade={{
-        initialValue: filterValues.gradeValue,
+        defaultValues: filterValues.gradeValue,
         onChange: (values) => dispatch(createGradeFilterChangedAction(values)),
       }}
       releaseYear={{
-        initialValue: filterValues.releaseYear,
+        defaultValues: filterValues.releaseYear,
         onChange: (values) =>
           dispatch(createReleaseYearFilterChangedAction(values)),
         values: distinctReleaseYears,
       }}
       reviewedStatus={{
-        initialValue: filterValues.reviewedStatus,
+        defaultValue: filterValues.reviewedStatus,
         onChange: (value) =>
           dispatch(createReviewedStatusFilterChangedAction(value)),
       }}
       reviewYear={{
-        initialValue: filterValues.reviewYear,
+        defaultValues: filterValues.reviewYear,
         onChange: (values) =>
           dispatch(createReviewYearFilterChangedAction(values)),
         values: distinctReviewYears,
       }}
       title={{
-        initialValue: filterValues.title,
+        defaultValue: filterValues.title,
         onChange: (value) => dispatch(createTitleFilterChangedAction(value)),
       }}
     />

--- a/src/features/collections/Filters.tsx
+++ b/src/features/collections/Filters.tsx
@@ -24,7 +24,7 @@ export function Filters({
   return (
     <CollectionFilters
       name={{
-        initialValue: filterValues.name,
+        defaultValue: filterValues.name,
         onChange: (value) => dispatch(createNameFilterChangedAction(value)),
       }}
     />

--- a/src/features/reviews/Filters.tsx
+++ b/src/features/reviews/Filters.tsx
@@ -37,28 +37,28 @@ export function Filters({
   return (
     <ReviewedTitleFilters
       genres={{
-        initialValue: filterValues.genres,
+        defaultValues: filterValues.genres,
         onChange: (values) => dispatch(createGenresFilterChangedAction(values)),
         values: distinctGenres,
       }}
       grade={{
-        initialValue: filterValues.gradeValue,
+        defaultValues: filterValues.gradeValue,
         onChange: (values) => dispatch(createGradeFilterChangedAction(values)),
       }}
       releaseYear={{
-        initialValue: filterValues.releaseYear,
+        defaultValues: filterValues.releaseYear,
         onChange: (values) =>
           dispatch(createReleaseYearFilterChangedAction(values)),
         values: distinctReleaseYears,
       }}
       reviewYear={{
-        initialValue: filterValues.reviewYear,
+        defaultValues: filterValues.reviewYear,
         onChange: (values) =>
           dispatch(createReviewYearFilterChangedAction(values)),
         values: distinctReviewYears,
       }}
       title={{
-        initialValue: filterValues.title,
+        defaultValue: filterValues.title,
         onChange: (value) => dispatch(createTitleFilterChangedAction(value)),
       }}
     />

--- a/src/features/viewings/Filters.tsx
+++ b/src/features/viewings/Filters.tsx
@@ -45,13 +45,13 @@ export function Filters({
     <>
       <TitleFilters
         releaseYear={{
-          initialValue: filterValues.releaseYear,
+          defaultValues: filterValues.releaseYear,
           onChange: (values) =>
             dispatch(createReleaseYearFilterChangedAction(values)),
           values: distinctReleaseYears,
         }}
         title={{
-          initialValue: filterValues.title,
+          defaultValue: filterValues.title,
           onChange: (value) => dispatch(createTitleFilterChangedAction(value)),
         }}
       />
@@ -62,7 +62,7 @@ export function Filters({
         }
       />
       <YearField
-        initialValues={filterValues.viewingYear}
+        defaultValues={filterValues.viewingYear}
         label="Viewing Year"
         onYearChange={(values) =>
           dispatch(createViewingYearFilterChangedAction(values))

--- a/src/features/watchlist/Filters.tsx
+++ b/src/features/watchlist/Filters.tsx
@@ -50,19 +50,19 @@ export function Filters({
     <>
       <TitleFilters
         genres={{
-          initialValue: filterValues.genres,
+          defaultValues: filterValues.genres,
           onChange: (values) =>
             dispatch(createGenresFilterChangedAction(values)),
           values: distinctGenres,
         }}
         releaseYear={{
-          initialValue: filterValues.releaseYear,
+          defaultValues: filterValues.releaseYear,
           onChange: (values) =>
             dispatch(createReleaseYearFilterChangedAction(values)),
           values: distinctReleaseYears,
         }}
         title={{
-          initialValue: filterValues.title,
+          defaultValue: filterValues.title,
           onChange: (value) => dispatch(createTitleFilterChangedAction(value)),
         }}
       />


### PR DESCRIPTION
## Summary

- Renamed `initialValue`/`initialValues` props to `defaultValue`/`defaultValues` across all field components
- Updated all filter components to use the new prop names
- Updated JSDoc comments to reflect the changes

## Motivation

This change aligns our prop naming with React's standard conventions for uncontrolled form inputs, which use `defaultValue` rather than `initialValue`. This improves consistency and makes the codebase more intuitive for React developers.

## Changes

### Field Components Updated:
- `GradeField.tsx`: `initialValues` → `defaultValues`
- `TextField.tsx`: `initialValue` → `defaultValue`  
- `YearField.tsx`: `initialValues` → `defaultValues`
- `MultiSelectField.tsx`: `initialValues` → `defaultValues`

### Filter Components Updated:
All filter components now pass the renamed props to their respective field components.

## Test Plan

✅ All tests passing
✅ ESLint passing
✅ Prettier formatting verified
✅ TypeScript check passing
✅ Knip (unused dependencies) check passing

🤖 Generated with [Claude Code](https://claude.ai/code)