### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: test
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/fshowalter/franksmovielog.com/security/code-scanning/3](https://github.com/fshowalter/franksmovielog.com/security/code-scanning/3)

To fix the problem, you should add an explicit `permissions` block to the workflow file to restrict the permissions of the `GITHUB_TOKEN` to only what is necessary for the workflow. Since this workflow only checks out code, sets up the environment, installs dependencies, and runs tests, it suffices to set the `contents` permission to `read`. This is best done by adding a `permissions: { contents: read }` block at the top level of the workflow (directly under the `name:` field and before `on:`), which ensures that all jobs default to these limited permissions unless overridden.

Only one file needs editing: `.github/workflows/test.yml`. Add the `permissions` block as described, after the `name:` line and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
