### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -1,4 +1,6 @@
 name: format & lint
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/fshowalter/franksmovielog.com/security/code-scanning/2](https://github.com/fshowalter/franksmovielog.com/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to restrict the GITHUB_TOKEN access to the minimum required rights. Since all steps are local read-only checks and do not require write access to repository contents or artifacts, you can set permissions to allow read-only access to contents, which is necessary for checkout and possibly for some GitHub Actions APIs. This can be set at the workflow level (top-level, to apply to all jobs) or at the job level (under `jobs.format-and-lint`). For clarity and maintainability, the workflow-wide setting is preferred here, directly after the workflow name. You only need to add:

```yaml
permissions:
  contents: read
```

on line 2, shifting the rest of the workflow down by one line. No additional dependencies or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
