### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,4 +1,7 @@
 name: build & deploy
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/fshowalter/franksmovielog.com/security/code-scanning/1](https://github.com/fshowalter/franksmovielog.com/security/code-scanning/1)

To fix this problem, you should add a `permissions` block explicitly to the workflow to restrict the actions that the `GITHUB_TOKEN` can perform. This can be done at the workflow root (before the `jobs:` key), applying default permissions to all jobs unless overridden, or just to the specific job. The steps in the workflow only need `contents: read` for actions such as checkout and reading files, but the deploy step (`nwtgck/actions-netlify`) uses `github-token`, likely for posting comments on pull requests and commits. Therefore, you should set `contents: read`, `pull-requests: write`, and possibly `statuses: write` if deployment status updates are needed. However, for a minimal starting point (per CodeQL's recommendation), giving at least `contents: read` is essential, and you can add others as needed if you confirm they are required. Add the following block after the workflow name and before `on:`:

```yaml
permissions:
  contents: read
  pull-requests: write
```

This change should be placed around line 2 of `.github/workflows/build-and-deploy.yml`. No code imports or other dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
