### PR TITLE
draft

### DIFF
--- a/src/components/filter-and-sort/fields/CheckboxListField.tsx
+++ b/src/components/filter-and-sort/fields/CheckboxListField.tsx
@@ -183,7 +183,9 @@ export function CheckboxListField({
                 <span className="flex-1 text-base text-default">
                   {option.label}
                 </span>
-                <span className="text-base text-subtle">({option.count})</span>
+                <span className="text-base text-subtle tabular-nums">
+                  ({option.count})
+                </span>
               </label>
             );
           })}

--- a/src/features/review/createReviewOpenGraphImageResponse.tsx
+++ b/src/features/review/createReviewOpenGraphImageResponse.tsx
@@ -127,15 +127,11 @@ async function getReviewOpenGraphImage({
     });
 
   if (cached) {
-    console.log(
-      `createReviewOpenGraphImageResponse: Review used cache entry for ${stillSlug}`,
-    );
+    console.log(` (reused cache entry)`);
     return cached;
   }
 
-  console.log(
-    `createReviewOpenGraphImageResponse: Cache miss for entry ${cacheProps}`,
-  );
+  console.log(` (cache miss for entry ${cacheProps})`);
 
   const still = await sharp(stillBuffer).resize(1200).toBuffer();
 

--- a/src/features/stats/Distribution.astro
+++ b/src/features/stats/Distribution.astro
@@ -41,7 +41,7 @@ const maxBar = values.reduce((total, value) => total + value.count, 0);
                 <div
                   class={`
                     col-start-3 self-center pb-1 text-right font-sans
-                    text-sm/3.5 text-nowrap text-subtle
+                    text-sm/3.5 text-nowrap text-subtle tabular-nums
                   `}
                 >
                   {value.count}

--- a/src/features/stats/MostWatchedPeople.astro
+++ b/src/features/stats/MostWatchedPeople.astro
@@ -81,7 +81,7 @@ const { header, values } = Astro.props;
                   <div
                     class={`
                       col-start-2 self-center pr-1 pb-1 text-right font-sans
-                      text-sm text-nowrap text-subtle
+                      text-sm text-nowrap text-subtle tabular-nums
                     `}
                   >
                     {person.count}

--- a/src/features/watchlist-progress/WatchlistProgressForGroup.astro
+++ b/src/features/watchlist-progress/WatchlistProgressForGroup.astro
@@ -119,7 +119,7 @@ const { class: className, label, values, valueType } = Astro.props;
                 <div
                   class={`
                     self-center pb-1 text-right font-sans text-xs leading-0
-                    text-nowrap
+                    text-nowrap tabular-nums
                   `}
                 >
                   {progressDetails.reviewCount} / {progressDetails.titleCount}

--- a/src/utils/createOpenGraphImageResponse.tsx
+++ b/src/utils/createOpenGraphImageResponse.tsx
@@ -68,7 +68,7 @@ async function getOpenGraphImage({
     });
 
   if (cached) {
-    console.log(` (reused cache entry`);
+    console.log(` (reused cache entry)`);
     return cached;
   }
 

--- a/src/utils/createOpenGraphImageResponse.tsx
+++ b/src/utils/createOpenGraphImageResponse.tsx
@@ -68,15 +68,11 @@ async function getOpenGraphImage({
     });
 
   if (cached) {
-    console.log(
-      `createOpenGraphImageResponse: Review used cache entry for ${backdropSlug}`,
-    );
+    console.log(` (reused cache entry`);
     return cached;
   }
 
-  console.log(
-    `createOpenGraphImageResponse: Cache miss for entry ${cacheProps}`,
-  );
+  console.log(` (cache miss for entry ${cacheProps})`);
 
   const still = await sharp(stillBuffer).resize(1200).toBuffer();
 


### PR DESCRIPTION
- **use `tabular-nums` for count displays across stats and filter components**
- **simplify OG image cache hit/miss log messages**
